### PR TITLE
feat(goland): 默认改为 GoLand，帖子按 Go 源码渲染

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 油猴脚本：把 [linux.do](https://linux.do/) 换成 **JetBrains IDE / Darcula** 风格。
 
+本仓库是 [czm15053/linuxdo-idea-ui](https://github.com/czm15053/linuxdo-idea-ui) 的 fork，默认外观为 **GoLand**，帖子按 Go 源码风格渲染。点击顶栏品牌标可在 GoLand → IntelliJ IDEA → PyCharm 之间循环。
+
 只换皮，不碰数据——内容、链接、按钮与交互全部保留。
 
 ## 安装
@@ -10,26 +12,28 @@
 2. 打开 [`linuxdo-idea.user.js`](./linuxdo-idea.user.js)，点 **Raw** 后安装
 3. 访问 <https://linux.do/>；脚本更新后请硬刷新一次
 
-Raw 直链（仓库公开后可用）：
+Raw 直链：
 
 ```text
-https://github.com/czm15053/linuxdo-idea-ui/raw/main/linuxdo-idea.user.js
+https://github.com/Q-xuan/linuxdo-idea-ui/raw/main/linuxdo-idea.user.js
 ```
 
 ## 功能
 
-- **IDEA / PyCharm 切换**：点击顶栏品牌标，选择写入 `localStorage`
+- **GoLand / IDEA / PyCharm 切换**：点击顶栏品牌标循环产品，选择写入 `localStorage`；未设置时默认 **GoLand**
 - **主页**：话题列表伪装为 **Git Log**（多泳道 SVG 图谱）
-- **话题页**：帖子渲染为代码编辑器阅读区（随产品切换 Java / Python 风）
+- **话题页**：帖子渲染为代码编辑器阅读区（随产品切换 Go / Java / Python 风）
 - **回帖**：混合语句模板；过短的回帖会补少量样板行
 - **代码行内图片**：默认收起，悬停预览，点击固定
-- **侧栏**：Project View 风格（路径栏、黄文件夹、箭头与选中色）
-- **工具窗条**：左右两侧 IDE 风格条带（Project / Commit / Maven / Python 等装饰按钮，窄屏自动隐藏）
-- **加载页面 / favicon / 菜单**：偏 IDE 壳层；通知区接近 Event Log
+- **侧栏**：Project View 风格（路径栏、黄文件夹、箭头与选中色；GoLand 下为 `cmd` / `internal` / `testdata` / `scratch`）
+- **工具窗条**：左右两侧 IDE 风格条带（Project / Commit / Go / Database 等装饰按钮，窄屏自动隐藏）
+- **加载页面 / favicon / 菜单**：偏 IDE 壳层；通知区接近 Event Log；状态栏随产品切换（如 `UTF-8 · tabs · Go · Darcula`）
 - **颜色模式**：跟随 linux.do 浅色 / 深色 / 自动；深色对齐 Darcula
 - **SPA**：站内跳转与前进后退后自动重新套用样式
 
 ## 截图
+
+下列快照仍来自上游的 IDEA / PyCharm 外观，尚未重拍 GoLand 默认态。
 
 | | |
 | --- | --- |
@@ -43,7 +47,7 @@ https://github.com/czm15053/linuxdo-idea-ui/raw/main/linuxdo-idea.user.js
 
 MIT © czm15053
 
-JetBrains、IntelliJ IDEA、PyCharm 均为 JetBrains s.r.o. 商标。本项目为非官方、非关联作品。
+JetBrains、IntelliJ IDEA、PyCharm、GoLand 均为 JetBrains s.r.o. 商标。本项目为非官方、非关联作品。
 
 ## 友链
 

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -191,7 +191,8 @@
       ],
       replyLink: goPrintlnStatement,
       replyList: goPrintlnStatement,
-      replyQuote: (indent, _comment, body) => goPrintlnStatement(indent, goQuoteHtmlAsRawString, body)
+      replyQuote: (indent, _comment, body) => goPrintlnStatement(indent, goQuoteHtmlAsRawString, body),
+      replyFillers: []
     },
     idea: {
       id: "idea",
@@ -3366,7 +3367,11 @@
             if (leftover && !isDiscourseImageCaption(leftover)) {
               painter.pushText(lines, escapeHtml(leftover));
             }
-            pushImageNodes(lines, child, commentPrefix);
+            const before = lines.length;
+            pushImageNodes(lines, child, "// ");
+            for (let i = before; i < lines.length; i += 1) {
+              lines[i] = `${product.indent}${lines[i]}`;
+            }
             continue;
           }
           pushImageNodes(lines, child, commentPrefix);
@@ -3457,11 +3462,12 @@
     if (!lines.length) {
       return asReply ? [painter.blank()] : [emptyComment];
     }
-    if (asReply) padShortReplyBody(lines, product);
+    if (asReply && product.id !== "goland") padShortReplyBody(lines, product);
     return lines;
   }
 
   function padShortReplyBody(lines, product = getProduct()) {
+    if (product.id === "goland") return;
     const MIN_BODY = 5;
     const bodyCount = lines.filter((l) => String(l || "").trim()).length;
     if (bodyCount >= MIN_BODY) return;
@@ -3635,7 +3641,7 @@
         ...buildFooterLines(post)
       ];
 
-      const signature = `v12:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v13:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -101,12 +101,12 @@
       breadcrumbFileLeaf: true,
       indent: "\t",
       comment: {
-        replyComment: "// ",
+        replyComment: "\t// ",
         bodyComment: "// ",
         quoteComment: "// > ",
         line: "//"
       },
-      paintBody: "raw-string",
+      paintBody: "statements",
       statusText: "UTF-8  ·  tabs  ·  Go 1.26  ·  Darcula  ·  Linux DO",
       statusLang: "Go",
       tabIcon: "linear-gradient(135deg, #00D886, #007DFE)",
@@ -141,7 +141,7 @@
         resources: "externalLibraries"
       },
       mark: GOLAND_MARK_SVG,
-      headerTopic({ name, floor, time, title, postNumber, cooked }) {
+      headerTopic({ name, floor, time, title, postNumber }) {
         const topic = String(title || "").replace(/\s+/g, " ").trim() || "未命名话题";
         const n = goFloorNumber(floor, postNumber);
         const meta = [
@@ -156,13 +156,12 @@
         ];
         if (meta) lines.push(`<span class="idea-cmt">// ${escapeHtml(meta)}。</span>`);
         lines.push(`<span class="idea-kw">package</span> topics`);
-        if (cookedHasImages(cooked)) {
-          lines.push(``);
-          lines.push(`<span class="idea-kw">import</span> <span class="idea-str">"fmt"</span>`);
-        }
+        lines.push(``);
+        lines.push(`<span class="idea-kw">func</span> <span class="idea-fn">Topic</span>() {`);
         return lines;
       },
       headerReply({ name, floor, time, replyTo, postNumber }) {
+        const ident = goPostIdent(name, postNumber);
         const n = goFloorNumber(floor, postNumber);
         const bits = [
           name ? `${name} 的 ${n} 楼` : `${n} 楼`,
@@ -171,40 +170,28 @@
         ]
           .filter(Boolean)
           .join("，");
-        return bits ? [`<span class="idea-cmt">// ${escapeHtml(bits)}。</span>`] : [];
+        const lines = [];
+        if (bits) lines.push(`<span class="idea-cmt">// ${escapeHtml(bits)}。</span>`);
+        lines.push(`<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() {`);
+        return lines;
       },
-      footerTopic({ name, floor, time, postNumber, body, cooked }) {
-        const n = goFloorNumber(floor, postNumber);
-        return [
-          ``,
-          `<span class="idea-kw">type</span> <span class="idea-fn">Post</span> <span class="idea-kw">struct</span> {`,
-          `\tAuthor, At, ReplyTo, Body <span class="idea-kw">string</span>`,
-          `\tFloor                     <span class="idea-kw">int</span>`,
-          `}`,
-          ``,
-          `<span class="idea-kw">var</span> Topic = <span class="idea-fn">Post</span>{`,
-          `\tAuthor: ${goStringLiteral(name || "")},`,
-          `\tFloor:  ${escapeHtml(n)},`,
-          ...(time ? [`\tAt:     ${goStringLiteral(time)},`] : []),
-          ...goBodyFieldLinesFromCooked(cooked, "\t", body),
-          `}`
-        ];
+      footerTopic() {
+        return [`}`];
       },
-      footerReply({ name, floor, time, replyTo, postNumber, body, cooked }) {
-        const ident = goPostIdent(name, postNumber);
-        const n = goFloorNumber(floor, postNumber);
-        return [
-          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() <span class="idea-fn">Post</span> {`,
-          `\t<span class="idea-kw">return</span> <span class="idea-fn">Post</span>{`,
-          `\t\tAuthor:  ${goStringLiteral(name || "anon")},`,
-          `\t\tFloor:   ${escapeHtml(n)},`,
-          ...(time ? [`\t\tAt:      ${goStringLiteral(time)},`] : []),
-          ...(replyTo ? [`\t\tReplyTo: ${goStringLiteral(replyTo)},`] : []),
-          ...goBodyFieldLinesFromCooked(cooked, "\t\t", body),
-          `\t}`,
-          `}`
-        ];
-      }
+      footerReply() {
+        return [`}`];
+      },
+      quoteString: goQuoteHtmlAsRawString,
+      replyPlain: [
+        goPrintlnStatement,
+        goPrintlnStatement,
+        goPrintlnStatement,
+        goPrintlnStatement,
+        goPrintlnStatement
+      ],
+      replyLink: goPrintlnStatement,
+      replyList: goPrintlnStatement,
+      replyQuote: (indent, _comment, body) => goPrintlnStatement(indent, goQuoteHtmlAsRawString, body)
     },
     idea: {
       id: "idea",
@@ -524,6 +511,42 @@
     return (pieces.join(" + ") || `<span class="idea-str">\`\`</span>`).split("\n");
   }
 
+  function goQuoteHtmlAsRawString(htmlOrText) {
+    const raw = String(htmlOrText ?? "");
+    const parts = raw.split("`");
+    if (parts.length === 1) {
+      const rows = parts[0].split("\n");
+      return rows
+        .map((row, i) => {
+          const open = i === 0 ? `<span class="idea-str">\`` : `<span class="idea-str">`;
+          const close = i === rows.length - 1 ? `\`</span>` : `</span>`;
+          return `${open}${row}${close}`;
+        })
+        .join("\n");
+    }
+    const pieces = [];
+    for (let i = 0; i < parts.length; i += 1) {
+      if (parts[i] !== "") {
+        const rows = parts[i].split("\n");
+        pieces.push(
+          rows
+            .map((row, li) => {
+              const open = li === 0 ? `<span class="idea-str">\`` : `<span class="idea-str">`;
+              const close = li === rows.length - 1 ? `\`</span>` : `</span>`;
+              return `${open}${row}${close}`;
+            })
+            .join("\n")
+        );
+      }
+      if (i < parts.length - 1) pieces.push(`<span class="idea-str">"\`"</span>`);
+    }
+    return pieces.join(" + ") || `<span class="idea-str">\`\`</span>`;
+  }
+
+  function goPrintlnStatement(indent, str, body) {
+    return `${indent}<span class="idea-fn">println</span>(${str(body)})`;
+  }
+
   function goBodyFieldLines(text, indent = "\t") {
     const rawLines = goRawStringDisplayLines(text);
     if (rawLines.length === 1) return [`${indent}Body: ${rawLines[0]},`];
@@ -682,51 +705,6 @@
 
     walk(cooked);
     return segments;
-  }
-
-  function cookedHasImages(cooked) {
-    return collectCookedBodySegments(cooked).some((seg) => seg.kind === "image");
-  }
-
-  function goEscapeFmtPercent(text) {
-    return String(text ?? "").replace(/%/g, "%%");
-  }
-
-  function goImageSprintfArgLine(src, indent) {
-    const safeSrc = escapeHtml(src || "");
-    return (
-      `${indent}${goStringLiteral(src)}, ` +
-      `<span class="idea-cmt">// [image]</span>` +
-      `<img class="idea-code-image-preview" data-src="${safeSrc}" alt="">`
-    );
-  }
-
-  function goBodyFieldLinesFromCooked(cooked, indent = "\t", fallback = "") {
-    if (!cooked) return goBodyFieldLines(fallback, indent);
-    const segments = collectCookedBodySegments(cooked);
-    const images = segments.filter((seg) => seg.kind === "image");
-    if (!images.length) {
-      return goBodyFieldLines(cookedToGoBody(cooked) || fallback, indent);
-    }
-
-    const formatText = segments
-      .map((seg) => (seg.kind === "image" ? "%s" : goEscapeFmtPercent(seg.text)))
-      .join("\n");
-    const rawLines = goRawStringDisplayLines(formatText);
-    const fmtCall = `fmt.<span class="idea-fn">Sprintf</span>(`;
-    const lines = [];
-    if (rawLines.length === 1) {
-      lines.push(`${indent}Body: ${fmtCall}${rawLines[0]},`);
-    } else {
-      lines.push(`${indent}Body: ${fmtCall}${rawLines[0]}`);
-      for (let i = 1; i < rawLines.length; i += 1) {
-        lines.push(i === rawLines.length - 1 ? `${rawLines[i]},` : rawLines[i]);
-      }
-    }
-    const argIndent = `${indent}\t`;
-    for (const img of images) lines.push(goImageSprintfArgLine(img.src, argIndent));
-    lines.push(`${indent}),`);
-    return lines;
   }
 
   function cookedToGoBody(cooked) {
@@ -3327,11 +3305,17 @@
       return tpl(indent, str, text);
     }
 
+    const keepMultiline = product.paintBody === "statements";
+
     return {
       pushText(bucket, textHtml, kind = "plain") {
         const inline = String(textHtml || "").replace(/\n+/g, "\n").trim();
         if (!inline) {
           bucket.push(paint("…", kind));
+          return;
+        }
+        if (keepMultiline) {
+          for (const row of String(paint(inline, kind)).split("\n")) bucket.push(row);
           return;
         }
         for (const part of inline.split("\n")) {
@@ -3377,6 +3361,14 @@
         }
 
         if (isImageContainer(child)) {
+          if (product.paintBody === "statements" && asReply) {
+            const leftover = leftoverCookedText(child);
+            if (leftover && !isDiscourseImageCaption(leftover)) {
+              painter.pushText(lines, escapeHtml(leftover));
+            }
+            pushImageNodes(lines, child, commentPrefix);
+            continue;
+          }
           pushImageNodes(lines, child, commentPrefix);
           const clone = child.cloneNode(true);
           for (const img of clone.querySelectorAll?.("img") || []) img.remove();
@@ -3390,6 +3382,9 @@
         }
 
         if (tag === "p" || tag === "div" || /^h[1-6]$/.test(tag)) {
+          if (product.paintBody === "statements" && asReply && lines.length && lines[lines.length - 1] !== "") {
+            lines.push("");
+          }
           const inline = serializeInline(child).replace(/\n+/g, "\n").trim();
           if (!inline) {
             if (!asReply) lines.push(`<span class="idea-cmt">${commentPrefix.trimEnd()}</span>`);
@@ -3405,6 +3400,9 @@
           continue;
         }
         if (tag === "ul" || tag === "ol") {
+          if (product.paintBody === "statements" && asReply && lines.length && lines[lines.length - 1] !== "") {
+            lines.push("");
+          }
           const items = child.querySelectorAll(":scope > li");
           let index = 1;
           for (const item of items) {
@@ -3417,6 +3415,9 @@
           continue;
         }
         if (tag === "blockquote") {
+          if (product.paintBody === "statements" && asReply && lines.length && lines[lines.length - 1] !== "") {
+            lines.push("");
+          }
           if (asReply) {
             const quoted = escapeHtml((child.textContent || "").replace(/\s+/g, " ").trim());
             if (quoted) painter.pushText(lines, quoted, "quote");
@@ -3627,14 +3628,14 @@
       const isReply = (post.getAttribute("data-post-number") || "1") !== "1";
       const product = getProduct();
       const embedBody = product.paintBody === "raw-string";
-      const paintReplyAsCode = isReply && !embedBody;
+      const paintAsStatements = !embedBody && (isReply || product.paintBody === "statements");
       const allLines = [
         ...buildHeaderLines(post),
-        ...(embedBody ? [] : collectCookedLineHtml(cooked, paintReplyAsCode)),
+        ...(embedBody ? [] : collectCookedLineHtml(cooked, paintAsStatements)),
         ...buildFooterLines(post)
       ];
 
-      const signature = `v11:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v12:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -4165,9 +4166,8 @@
       goStringLiteral,
       goRawStringDisplayLines,
       goBodyFieldLines,
-      goBodyFieldLinesFromCooked,
-      cookedHasImages,
-      goEscapeFmtPercent,
+      goQuoteHtmlAsRawString,
+      goPrintlnStatement,
       cookedToGoBody,
       leftoverCookedText,
       isDiscourseImageCaption,

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -140,29 +140,44 @@
         resources: "externalLibraries"
       },
       mark: GOLAND_MARK_SVG,
-      headerTopic({ name, floor, time, stem, title }) {
+      headerTopic({ name, floor, time, stem, title, postNumber }) {
+        const topic = String(title || "").replace(/\s+/g, " ").trim() || "未命名话题";
         const typeName = exportedIdent(title || stem);
-        return [
-          `<span class="idea-kw">package</span> topics`,
-          ``,
-          `<span class="idea-kw">import</span> <span class="idea-str">"community/discourse"</span>`,
-          ``,
-          `<span class="idea-cmt">// <span class="idea-ann">@author</span> ${escapeHtml(name || "")}</span>`,
-          floor
-            ? `<span class="idea-cmt">// <span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
-            : `<span class="idea-cmt">//</span>`,
-          time
-            ? `<span class="idea-cmt">// <span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
-            : `<span class="idea-cmt">//</span>`,
-          `<span class="idea-kw">type</span> <span class="idea-fn">${escapeHtml(typeName)}</span> <span class="idea-kw">struct</span> {`
+        const n = goFloorNumber(floor, postNumber);
+        const meta = [
+          name ? `作者 ${name}` : "",
+          n ? `楼层 ${n}` : "",
+          time ? `发表于 ${time}` : ""
+        ]
+          .filter(Boolean)
+          .join("，");
+        const lines = [
+          `<span class="idea-cmt">// Package topics 记录「${escapeHtml(topic)}」。</span>`
         ];
+        if (meta) lines.push(`<span class="idea-cmt">// ${escapeHtml(meta)}。</span>`);
+        lines.push(`<span class="idea-kw">package</span> topics`);
+        lines.push(``);
+        lines.push(`<span class="idea-kw">import</span> <span class="idea-str">"community/discourse"</span>`);
+        lines.push(``);
+        lines.push(
+          `<span class="idea-kw">type</span> <span class="idea-fn">${escapeHtml(typeName)}</span> <span class="idea-kw">struct</span> {`
+        );
+        return lines;
       },
-      headerReply({ methodName, meta }) {
+      headerReply({ methodName, name, floor, time, replyTo, postNumber }) {
+        const ident = methodName || "reply_user_0";
+        const n = goFloorNumber(floor, postNumber);
+        const bits = [
+          name ? `${name} 的 ${n} 楼` : `${n} 楼`,
+          time,
+          replyTo ? `回复 ${replyTo}` : ""
+        ]
+          .filter(Boolean)
+          .join("，");
         return [
           ``,
-          `<span class="idea-cmt">// ${escapeHtml(meta)}</span>`,
-          `<span class="idea-ann">//go:reply</span>`,
-          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(methodName)}</span>() {`
+          `<span class="idea-cmt">// ${escapeHtml(ident)} 是 ${escapeHtml(bits)}。</span>`,
+          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() {`
         ];
       },
       footerTopic() {
@@ -187,13 +202,7 @@
         `${indent}items = <span class="idea-fn">append</span>(items, ${str(body)})`,
       replyQuote: (indent, comment, body) =>
         `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
-      replyFillers: [
-        `\t<span class="idea-kw">if</span> msg == <span class="idea-str">""</span> {`,
-        `\t\t<span class="idea-kw">return</span>`,
-        `\t}`,
-        `\tctx.<span class="idea-fn">Touch</span>()`,
-        `\tmetrics.<span class="idea-fn">Inc</span>(<span class="idea-str">"reply"</span>)`
-      ]
+      replyFillers: []
     },
     idea: {
       id: "idea",
@@ -3438,11 +3447,12 @@
     if (!lines.length) {
       return asReply ? [painter.blank()] : [emptyComment];
     }
-    if (asReply) padShortReplyBody(lines, product);
+    if (asReply && product.id !== "goland") padShortReplyBody(lines, product);
     return lines;
   }
 
   function padShortReplyBody(lines, product = getProduct()) {
+    if (product.id === "goland") return;
     const MIN_BODY = 5;
     const bodyCount = lines.filter((l) => String(l || "").trim()).length;
     if (bodyCount >= MIN_BODY) return;
@@ -3616,7 +3626,7 @@
         ...buildFooterLines(post)
       ];
 
-      const signature = `v14:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v15:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -167,11 +167,7 @@
         ]
           .filter(Boolean)
           .join("，");
-        return [
-          `<span class="idea-kw">package</span> topics`,
-          ``,
-          bits ? `<span class="idea-cmt">// ${escapeHtml(bits)}。</span>` : ``
-        ];
+        return bits ? [`<span class="idea-cmt">// ${escapeHtml(bits)}。</span>`] : [];
       },
       footerTopic({ name, floor, time, postNumber, body }) {
         const n = goFloorNumber(floor, postNumber);
@@ -194,12 +190,14 @@
         const ident = goPostIdent(name, postNumber);
         const n = goFloorNumber(floor, postNumber);
         return [
-          `<span class="idea-kw">var</span> ${escapeHtml(ident)} = <span class="idea-fn">Post</span>{`,
-          `\tAuthor:  ${goStringLiteral(name || "anon")},`,
-          `\tFloor:   ${escapeHtml(n)},`,
-          ...(time ? [`\tAt:      ${goStringLiteral(time)},`] : []),
-          ...(replyTo ? [`\tReplyTo: ${goStringLiteral(replyTo)},`] : []),
-          ...goBodyFieldLines(body),
+          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() <span class="idea-fn">Post</span> {`,
+          `\t<span class="idea-kw">return</span> <span class="idea-fn">Post</span>{`,
+          `\t\tAuthor:  ${goStringLiteral(name || "anon")},`,
+          `\t\tFloor:   ${escapeHtml(n)},`,
+          ...(time ? [`\t\tAt:      ${goStringLiteral(time)},`] : []),
+          ...(replyTo ? [`\t\tReplyTo: ${goStringLiteral(replyTo)},`] : []),
+          ...goBodyFieldLines(body, "\t\t"),
+          `\t}`,
           `}`
         ];
       }
@@ -522,10 +520,10 @@
     return (pieces.join(" + ") || `<span class="idea-str">\`\`</span>`).split("\n");
   }
 
-  function goBodyFieldLines(text) {
+  function goBodyFieldLines(text, indent = "\t") {
     const rawLines = goRawStringDisplayLines(text);
-    if (rawLines.length === 1) return [`\tBody: ${rawLines[0]},`];
-    const lines = [`\tBody: ${rawLines[0]}`];
+    if (rawLines.length === 1) return [`${indent}Body: ${rawLines[0]},`];
+    const lines = [`${indent}Body: ${rawLines[0]}`];
     for (let i = 1; i < rawLines.length; i += 1) {
       lines.push(i === rawLines.length - 1 ? `${rawLines[i]},` : rawLines[i]);
     }

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -101,12 +101,11 @@
       breadcrumbFileLeaf: true,
       indent: "\t",
       comment: {
-        replyComment: "\t// ",
-        bodyComment: "// ",
-        quoteComment: "// > ",
+        replyComment: "// ",
+        bodyComment: "\t// ",
+        quoteComment: "\t// > ",
         line: "//"
       },
-      paintBody: "statements",
       statusText: "UTF-8  ·  tabs  ·  Go 1.26  ·  Darcula  ·  Linux DO",
       statusLang: "Go",
       tabIcon: "linear-gradient(135deg, #00D886, #007DFE)",
@@ -141,39 +140,30 @@
         resources: "externalLibraries"
       },
       mark: GOLAND_MARK_SVG,
-      headerTopic({ name, floor, time, title, postNumber }) {
-        const topic = String(title || "").replace(/\s+/g, " ").trim() || "未命名话题";
-        const n = goFloorNumber(floor, postNumber);
-        const meta = [
-          name ? `作者 ${name}` : "",
-          n ? `楼层 ${n}` : "",
-          time ? `发表于 ${time}` : ""
-        ]
-          .filter(Boolean)
-          .join("，");
-        const lines = [
-          `<span class="idea-cmt">// Package topics 记录「${escapeHtml(topic)}」。</span>`
+      headerTopic({ name, floor, time, stem, title }) {
+        const typeName = exportedIdent(title || stem);
+        return [
+          `<span class="idea-kw">package</span> topics`,
+          ``,
+          `<span class="idea-kw">import</span> <span class="idea-str">"community/discourse"</span>`,
+          ``,
+          `<span class="idea-cmt">// <span class="idea-ann">@author</span> ${escapeHtml(name || "")}</span>`,
+          floor
+            ? `<span class="idea-cmt">// <span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
+            : `<span class="idea-cmt">//</span>`,
+          time
+            ? `<span class="idea-cmt">// <span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
+            : `<span class="idea-cmt">//</span>`,
+          `<span class="idea-kw">type</span> <span class="idea-fn">${escapeHtml(typeName)}</span> <span class="idea-kw">struct</span> {`
         ];
-        if (meta) lines.push(`<span class="idea-cmt">// ${escapeHtml(meta)}。</span>`);
-        lines.push(`<span class="idea-kw">package</span> topics`);
-        lines.push(``);
-        lines.push(`<span class="idea-kw">func</span> <span class="idea-fn">Topic</span>() {`);
-        return lines;
       },
-      headerReply({ name, floor, time, replyTo, postNumber }) {
-        const ident = goPostIdent(name, postNumber);
-        const n = goFloorNumber(floor, postNumber);
-        const bits = [
-          name ? `${name} 的 ${n} 楼` : `${n} 楼`,
-          time,
-          replyTo ? `回复 ${replyTo}` : ""
-        ]
-          .filter(Boolean)
-          .join("，");
-        const lines = [];
-        if (bits) lines.push(`<span class="idea-cmt">// ${escapeHtml(bits)}。</span>`);
-        lines.push(`<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() {`);
-        return lines;
+      headerReply({ methodName, meta }) {
+        return [
+          ``,
+          `<span class="idea-cmt">// ${escapeHtml(meta)}</span>`,
+          `<span class="idea-ann">//go:reply</span>`,
+          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(methodName)}</span>() {`
+        ];
       },
       footerTopic() {
         return [`}`];
@@ -183,16 +173,27 @@
       },
       quoteString: goQuoteHtmlAsRawString,
       replyPlain: [
-        goPrintlnStatement,
-        goPrintlnStatement,
-        goPrintlnStatement,
-        goPrintlnStatement,
-        goPrintlnStatement
+        (indent, str, body) =>
+          `${indent}<span class="idea-fn">log</span>.<span class="idea-fn">Print</span>(${str(body)})`,
+        (indent, str, body) =>
+          `${indent}notes = <span class="idea-fn">append</span>(notes, ${str(body)})`,
+        (indent, str, body) =>
+          `${indent}<span class="idea-kw">if</span> <span class="idea-fn">len</span>(${str(body)}) == 0 { <span class="idea-fn">panic</span>(<span class="idea-str">"empty"</span>) }`,
+        (indent, str, body) => `${indent}ctx.<span class="idea-fn">Reply</span>(${str(body)})`,
+        (indent, str, body) => `${indent}msg := ${str(body)}`
       ],
-      replyLink: goPrintlnStatement,
-      replyList: goPrintlnStatement,
-      replyQuote: (indent, _comment, body) => goPrintlnStatement(indent, goQuoteHtmlAsRawString, body),
-      replyFillers: []
+      replyLink: (indent, str, body) => `${indent}ctx.<span class="idea-fn">Open</span>(${str(body)})`,
+      replyList: (indent, str, body) =>
+        `${indent}items = <span class="idea-fn">append</span>(items, ${str(body)})`,
+      replyQuote: (indent, comment, body) =>
+        `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
+      replyFillers: [
+        `\t<span class="idea-kw">if</span> msg == <span class="idea-str">""</span> {`,
+        `\t\t<span class="idea-kw">return</span>`,
+        `\t}`,
+        `\tctx.<span class="idea-fn">Touch</span>()`,
+        `\tmetrics.<span class="idea-fn">Inc</span>(<span class="idea-str">"reply"</span>)`
+      ]
     },
     idea: {
       id: "idea",
@@ -3306,17 +3307,11 @@
       return tpl(indent, str, text);
     }
 
-    const keepMultiline = product.paintBody === "statements";
-
     return {
       pushText(bucket, textHtml, kind = "plain") {
         const inline = String(textHtml || "").replace(/\n+/g, "\n").trim();
         if (!inline) {
           bucket.push(paint("…", kind));
-          return;
-        }
-        if (keepMultiline) {
-          for (const row of String(paint(inline, kind)).split("\n")) bucket.push(row);
           return;
         }
         for (const part of inline.split("\n")) {
@@ -3362,24 +3357,14 @@
         }
 
         if (isImageContainer(child)) {
-          if (product.paintBody === "statements" && asReply) {
-            const leftover = leftoverCookedText(child);
-            if (leftover && !isDiscourseImageCaption(leftover)) {
-              painter.pushText(lines, escapeHtml(leftover));
-            }
-            const before = lines.length;
-            pushImageNodes(lines, child, "// ");
-            for (let i = before; i < lines.length; i += 1) {
-              lines[i] = `${product.indent}${lines[i]}`;
-            }
-            continue;
-          }
-          pushImageNodes(lines, child, commentPrefix);
+          const imagePrefix =
+            asReply && product.id === "goland" ? `${product.indent}// ` : commentPrefix;
+          pushImageNodes(lines, child, imagePrefix);
           const clone = child.cloneNode(true);
           for (const img of clone.querySelectorAll?.("img") || []) img.remove();
           for (const a of clone.querySelectorAll?.("a.lightbox") || []) a.remove();
           const leftover = (clone.textContent || "").trim();
-          if (leftover) {
+          if (leftover && !(product.id === "goland" && isDiscourseImageCaption(leftover))) {
             if (asReply) painter.pushText(lines, escapeHtml(leftover));
             else pushCommentLines(lines, leftover, commentPrefix);
           }
@@ -3387,9 +3372,6 @@
         }
 
         if (tag === "p" || tag === "div" || /^h[1-6]$/.test(tag)) {
-          if (product.paintBody === "statements" && asReply && lines.length && lines[lines.length - 1] !== "") {
-            lines.push("");
-          }
           const inline = serializeInline(child).replace(/\n+/g, "\n").trim();
           if (!inline) {
             if (!asReply) lines.push(`<span class="idea-cmt">${commentPrefix.trimEnd()}</span>`);
@@ -3405,9 +3387,6 @@
           continue;
         }
         if (tag === "ul" || tag === "ol") {
-          if (product.paintBody === "statements" && asReply && lines.length && lines[lines.length - 1] !== "") {
-            lines.push("");
-          }
           const items = child.querySelectorAll(":scope > li");
           let index = 1;
           for (const item of items) {
@@ -3420,9 +3399,6 @@
           continue;
         }
         if (tag === "blockquote") {
-          if (product.paintBody === "statements" && asReply && lines.length && lines[lines.length - 1] !== "") {
-            lines.push("");
-          }
           if (asReply) {
             const quoted = escapeHtml((child.textContent || "").replace(/\s+/g, " ").trim());
             if (quoted) painter.pushText(lines, quoted, "quote");
@@ -3462,12 +3438,11 @@
     if (!lines.length) {
       return asReply ? [painter.blank()] : [emptyComment];
     }
-    if (asReply && product.id !== "goland") padShortReplyBody(lines, product);
+    if (asReply) padShortReplyBody(lines, product);
     return lines;
   }
 
   function padShortReplyBody(lines, product = getProduct()) {
-    if (product.id === "goland") return;
     const MIN_BODY = 5;
     const bodyCount = lines.filter((l) => String(l || "").trim()).length;
     if (bodyCount >= MIN_BODY) return;
@@ -3634,14 +3609,14 @@
       const isReply = (post.getAttribute("data-post-number") || "1") !== "1";
       const product = getProduct();
       const embedBody = product.paintBody === "raw-string";
-      const paintAsStatements = !embedBody && (isReply || product.paintBody === "statements");
+      const paintReplyAsCode = isReply && !embedBody;
       const allLines = [
         ...buildHeaderLines(post),
-        ...(embedBody ? [] : collectCookedLineHtml(cooked, paintAsStatements)),
+        ...(embedBody ? [] : collectCookedLineHtml(cooked, paintReplyAsCode)),
         ...buildFooterLines(post)
       ];
 
-      const signature = `v13:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v14:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         Linux DO · JetBrains / Darcula 外观
 // @namespace    https://linux.do/
-// @version      0.1.1
-// @description  将 Linux DO 的主页与话题页换成 JetBrains IDE / Darcula 风格（支持 IDEA / PyCharm 切换）。仅改变外观，保留站点原有内容与交互。
+// @version      0.2.0
+// @description  将 Linux DO 的主页与话题页换成 JetBrains IDE / Darcula 风格（默认 GoLand，可切换 IDEA / PyCharm）。仅改变外观，保留站点原有内容与交互。
 // @author       czm15053
 // @match        https://linux.do/*
 // @icon         https://linux.do/favicon.ico
@@ -68,13 +68,150 @@
     <rect x="17" y="44" width="16" height="3" fill="#fff"/>
   </svg>`;
 
+  const GOLAND_MARK_SVG = (idPrefix, sizeAttr) => `<svg ${sizeAttr} viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <defs>
+      <linearGradient id="${idPrefix}-a" x1="64.391" x2="39.607" y1="56.329" y2="2.874" gradientUnits="userSpaceOnUse">
+        <stop offset="0.24" stop-color="#00D886"/>
+        <stop offset="0.51" stop-color="#007DFE"/>
+      </linearGradient>
+      <linearGradient id="${idPrefix}-b" x1="59.676" x2="1.08" y1="4.067" y2="62.663" gradientUnits="userSpaceOnUse">
+        <stop offset="0.27" stop-color="#007DFE"/>
+        <stop offset="0.7" stop-color="#D249FC"/>
+      </linearGradient>
+    </defs>
+    <path fill="#00D886" d="M47.55 58h12.259a4.125 4.125 0 0 0 4.124-4.19l-.176-11.044a4.13 4.13 0 0 0-1.44-3.066L24.159 6.993A4.13 4.13 0 0 0 21.474 6H10.125A4.125 4.125 0 0 0 6 10.125v11.003c0 1.19.514 2.321 1.409 3.105l37.425 32.746A4.12 4.12 0 0 0 47.55 58"/>
+    <path fill="url(#${idPrefix}-a)" d="M49.013 58h10.862A4.125 4.125 0 0 0 64 53.875V41.309q0-.3-.044-.598L58.508 3.527A4.124 4.124 0 0 0 54.427 0H39.029a4.125 4.125 0 0 0-4.125 4.126l.005 18.505c0 .425.066.848.195 1.253l9.979 31.246a4.13 4.13 0 0 0 3.93 2.87"/>
+    <path fill="url(#${idPrefix}-b)" d="M4.125 64h34.128a4.13 4.13 0 0 0 3.8-2.52L57.85 24.057c.219-.518.33-1.076.324-1.638l-.15-18.329A4.124 4.124 0 0 0 53.9 0H36.234c-.805 0-1.593.236-2.266.678L1.86 21.787A4.13 4.13 0 0 0 0 25.234v34.641A4.125 4.125 0 0 0 4.125 64"/>
+    <rect x="12" y="12" width="40" height="40" fill="#000"/>
+    <path fill="#fff" d="M19.748 31.243a7.3 7.3 0 0 1-2.743-2.787q-.997-1.774-.997-3.961c0-2.187.332-2.778.997-3.96s1.58-2.112 2.743-2.787q1.747-1.013 3.902-1.014 1.747 0 3.222.622a6.9 6.9 0 0 1 2.486 1.747 6.4 6.4 0 0 1 1.42 2.594h-3.13a3.9 3.9 0 0 0-.926-1.228q-.584-.52-1.367-.803c-.783-.283-1.083-.284-1.683-.284q-1.33 0-2.402.664a4.6 4.6 0 0 0-1.677 1.828q-.606 1.163-.606 2.62c0 1.457.202 1.846.606 2.621a4.6 4.6 0 0 0 1.677 1.828q1.072.664 2.402.664 1.232 0 2.235-.461t1.591-1.276a3.3 3.3 0 0 0 .633-1.833l.01.31h-3.526v-2.304h6.357v1.18q0 1.982-.96 3.585a6.9 6.9 0 0 1-2.626 2.525q-1.666.921-3.736.921c-2.07 0-2.737-.337-3.902-1.013zM36.271 31.243a7.3 7.3 0 0 1-2.755-2.787q-1.002-1.774-1.002-3.961c0-2.187.333-2.778 1.002-3.96a7.3 7.3 0 0 1 2.755-2.787q1.752-1.013 3.918-1.014c1.443 0 2.738.338 3.907 1.013a7.3 7.3 0 0 1 2.749 2.787q.996 1.774.997 3.961c0 2.187-.333 2.778-.997 3.96s-1.581 2.113-2.75 2.788q-1.752 1.013-3.906 1.013c-1.437 0-2.75-.338-3.918-1.013m6.308-2.23q1.062-.67 1.662-1.854t.6-2.664-.6-2.664-1.662-1.854-2.39-.67-2.395.67a4.6 4.6 0 0 0-1.672 1.854q-.606 1.185-.606 2.664t.606 2.664 1.672 1.854 2.395.67q1.33 0 2.39-.67"/>
+    <rect x="17" y="44" width="16" height="3" fill="#fff"/>
+  </svg>`;
+
+  const PRODUCT_ORDER = ["goland", "idea", "pycharm"];
+  const DEFAULT_PRODUCT_ID = "goland";
+
   const PRODUCTS = {
+    goland: {
+      id: "goland",
+      name: "GoLand",
+      accent: "#00D886",
+      ext: "go",
+      contextRoot: "cmd",
+      newFileLabel: "New File",
+      breadcrumbFileLeaf: true,
+      indent: "\t",
+      comment: {
+        replyComment: "// ",
+        bodyComment: "\t// ",
+        quoteComment: "// > ",
+        line: "//"
+      },
+      statusText: "UTF-8  ·  tabs  ·  Go  ·  Darcula  ·  Linux DO",
+      statusLang: "Go",
+      tabIcon: "linear-gradient(135deg, #00D886, #007DFE)",
+      menus: [
+        "File",
+        "Edit",
+        "View",
+        "Navigate",
+        "Code",
+        "Refactor",
+        "Run",
+        "Tools",
+        "VCS",
+        "Window",
+        "Help"
+      ],
+      stripLeft: [
+        { label: "Project", icon: "folder", active: true },
+        { label: "Commit", icon: "commit" },
+        { label: "Structure", icon: "structure" }
+      ],
+      stripRight: [
+        { label: "Go", icon: "go" },
+        { label: "Database", icon: "database" },
+        { label: "AI", icon: "ai" }
+      ],
+      sidebarAliases: {
+        categories: "cmd",
+        tags: "internal",
+        chat: "testdata",
+        dms: "scratch",
+        resources: "externalLibraries"
+      },
+      mark: GOLAND_MARK_SVG,
+      headerTopic({ name, floor, time, stem }) {
+        const ident = exportedIdent(stem);
+        return [
+          `<span class="idea-kw">package</span> topics`,
+          ``,
+          `<span class="idea-kw">import</span> <span class="idea-str">"linux.do/community/discourse"</span>`,
+          ``,
+          `<span class="idea-cmt">// <span class="idea-ann">@author</span> ${escapeHtml(name)}</span>`,
+          floor
+            ? `<span class="idea-cmt">// <span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
+            : ``,
+          time
+            ? `<span class="idea-cmt">// <span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
+            : ``,
+          ``,
+          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() {`,
+          ``
+        ];
+      },
+      headerReply({ methodName, meta }) {
+        return [
+          ``,
+          `<span class="idea-cmt">// ${escapeHtml(meta)}</span>`,
+          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(methodName)}</span>() {`
+        ];
+      },
+      footerTopic() {
+        return [``, `<span class="idea-kw">}</span> <span class="idea-cmt">// end of topic</span>`];
+      },
+      footerReply() {
+        return [`<span class="idea-kw">}</span>`];
+      },
+      replyPlain: [
+        (indent, str, body) =>
+          `${indent}<span class="idea-fn">log</span>.<span class="idea-fn">Printf</span>(<span class="idea-str">"%s"</span>, ${str(body)})`,
+        (indent, str, body) =>
+          `${indent}notes = <span class="idea-fn">append</span>(notes, ${str(body)})`,
+        (indent, str, body) =>
+          `${indent}<span class="idea-kw">if</span> ${str(body)} == <span class="idea-str">""</span> { <span class="idea-kw">return</span> }`,
+        (indent, str, body) => `${indent}ctx.<span class="idea-fn">Reply</span>(${str(body)})`,
+        (indent, str, body) => `${indent}msg := ${str(body)}`
+      ],
+      replyLink: (indent, str, body) => `${indent}ctx.<span class="idea-fn">Open</span>(${str(body)})`,
+      replyList: (indent, str, body) =>
+        `${indent}items = <span class="idea-fn">append</span>(items, ${str(body)})`,
+      replyQuote: (indent, comment, body) =>
+        `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
+      replyFillers: [
+        `\t<span class="idea-kw">if</span> msg == <span class="idea-str">""</span> { <span class="idea-kw">return</span> }`,
+        `\tctx.<span class="idea-fn">Touch</span>()`,
+        `\tsort.<span class="idea-fn">Strings</span>(notes)`,
+        `\tmetrics.<span class="idea-fn">Inc</span>(<span class="idea-str">"reply"</span>)`
+      ]
+    },
     idea: {
       id: "idea",
       name: "IntelliJ IDEA",
       accent: "#4A9FD8",
       ext: "java",
       contextRoot: "topics",
+      newFileLabel: "New Class",
+      breadcrumbFileLeaf: false,
+      indent: "  ",
+      comment: {
+        replyComment: "// ",
+        bodyComment: "  // ",
+        quoteComment: "// > ",
+        line: "//"
+      },
+      statusText: "UTF-8  ·  4 spaces  ·  Java  ·  Darcula  ·  Linux DO",
+      statusLang: "Java",
+      tabIcon: "linear-gradient(135deg, #CC7832, #6A8759)",
       menus: [
         "File",
         "Edit",
@@ -99,7 +236,70 @@
         { label: "Database", icon: "database" },
         { label: "AI", icon: "ai" }
       ],
-      mark: IDEA_MARK_SVG
+      sidebarAliases: {
+        categories: "directories",
+        tags: "packages",
+        chat: "resources",
+        dms: "scratch",
+        resources: "externalLibraries"
+      },
+      mark: IDEA_MARK_SVG,
+      headerTopic({ name, floor, time, stem }) {
+        return [
+          `<span class="idea-kw">package</span> <span class="idea-str">linux.do.topics</span>;`,
+          ``,
+          `<span class="idea-kw">import</span> <span class="idea-str">community.discourse.*</span>;`,
+          ``,
+          `<span class="idea-cmt">/**</span>`,
+          `<span class="idea-cmt"> * <span class="idea-ann">@author</span> ${escapeHtml(name)}</span>`,
+          floor
+            ? `<span class="idea-cmt"> * <span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
+            : `<span class="idea-cmt"> *</span>`,
+          time
+            ? `<span class="idea-cmt"> * <span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
+            : `<span class="idea-cmt"> *</span>`,
+          `<span class="idea-cmt"> */</span>`,
+          `<span class="idea-kw">public class</span> <span class="idea-fn">${escapeHtml(stem)}</span> {`,
+          ``
+        ];
+      },
+      headerReply({ methodName, meta }) {
+        return [
+          ``,
+          `<span class="idea-cmt">// ${escapeHtml(meta)}</span>`,
+          `<span class="idea-ann">@Reply</span>`,
+          `<span class="idea-kw">void</span> <span class="idea-fn">${escapeHtml(methodName)}</span>() {`
+        ];
+      },
+      footerTopic() {
+        return [``, `<span class="idea-kw">}</span> <span class="idea-cmt">// end of topic</span>`];
+      },
+      footerReply() {
+        return [`<span class="idea-kw">}</span>`];
+      },
+      replyPlain: [
+        (indent, str, body) =>
+          `${indent}<span class="idea-fn">log</span>.<span class="idea-fn">info</span>(${str(body)});`,
+        (indent, str, body) => `${indent}notes.<span class="idea-fn">add</span>(${str(body)});`,
+        (indent, str, body) =>
+          `${indent}<span class="idea-kw">assert</span> ${str(body)}.<span class="idea-fn">length</span>() > 0;`,
+        (indent, str, body) => `${indent}ctx.<span class="idea-fn">reply</span>(${str(body)});`,
+        (indent, str, body) => `${indent}<span class="idea-kw">var</span> msg = ${str(body)};`
+      ],
+      replyLink: (indent, str, body) =>
+        `${indent}ctx.<span class="idea-fn">open</span>(${str(body)});`,
+      replyList: (indent, str, body) =>
+        `${indent}items.<span class="idea-fn">add</span>(${str(body)});`,
+      replyQuote: (indent, comment, body) =>
+        `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
+      replyFillers: [
+        `  <span class="idea-kw">if</span> (msg == <span class="idea-kw">null</span> || msg.<span class="idea-fn">isBlank</span>()) {`,
+        `    <span class="idea-kw">return</span>;`,
+        `  }`,
+        `  ctx.<span class="idea-fn">touch</span>();`,
+        `  notes.<span class="idea-fn">sort</span>(<span class="idea-kw">null</span>);`,
+        `  Metrics.<span class="idea-fn">inc</span>(<span class="idea-str">"reply"</span>);`
+      ]
     },
     pycharm: {
       id: "pycharm",
@@ -107,6 +307,18 @@
       accent: "#21D789",
       ext: "py",
       contextRoot: "src",
+      newFileLabel: "New File",
+      breadcrumbFileLeaf: true,
+      indent: "    ",
+      comment: {
+        replyComment: "# ",
+        bodyComment: "    # ",
+        quoteComment: "# > ",
+        line: "#"
+      },
+      statusText: "UTF-8  ·  4 spaces  ·  Python  ·  Darcula  ·  Linux DO",
+      statusLang: "Python",
+      tabIcon: "linear-gradient(135deg, #3572A5, #21D789)",
       menus: [
         "File",
         "Edit",
@@ -130,23 +342,71 @@
         { label: "Database", icon: "database" },
         { label: "AI", icon: "ai" }
       ],
-      mark: PYCHARM_MARK_SVG
+      sidebarAliases: {
+        categories: "src",
+        tags: "packages",
+        chat: "notebooks",
+        dms: "scratch",
+        resources: "externalLibraries"
+      },
+      mark: PYCHARM_MARK_SVG,
+      headerTopic({ name, floor, time, stem }) {
+        return [
+          `<span class="idea-cmt">"""linux.do.topics</span>`,
+          ``,
+          `<span class="idea-cmt"><span class="idea-ann">@author</span> ${escapeHtml(name)}</span>`,
+          floor
+            ? `<span class="idea-cmt"><span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
+            : ``,
+          time
+            ? `<span class="idea-cmt"><span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
+            : ``,
+          `<span class="idea-cmt">"""</span>`,
+          ``,
+          `<span class="idea-kw">from</span> <span class="idea-str">community.discourse</span> <span class="idea-kw">import</span> *`,
+          ``,
+          `<span class="idea-kw">class</span> <span class="idea-fn">${escapeHtml(stem)}</span>:`,
+          ``
+        ];
+      },
+      headerReply({ methodName, meta }) {
+        return [
+          ``,
+          `<span class="idea-cmt"># ${escapeHtml(meta)}</span>`,
+          `<span class="idea-kw">def</span> <span class="idea-fn">${escapeHtml(methodName)}</span>():`
+        ];
+      },
+      footerTopic() {
+        return [``, `<span class="idea-cmt"># end of topic</span>`];
+      },
+      footerReply() {
+        return [];
+      },
+      replyPlain: [
+        (indent, str, body) =>
+          `${indent}<span class="idea-fn">logger</span>.<span class="idea-fn">info</span>(${str(body)})`,
+        (indent, str, body) => `${indent}notes.<span class="idea-fn">append</span>(${str(body)})`,
+        (indent, str, body) => `${indent}<span class="idea-kw">assert</span> ${str(body)}`,
+        (indent, str, body) => `${indent}ctx.<span class="idea-fn">reply</span>(${str(body)})`,
+        (indent, str, body) => `${indent}msg = ${str(body)}`
+      ],
+      replyLink: (indent, str, body) => `${indent}ctx.<span class="idea-fn">open</span>(${str(body)})`,
+      replyList: (indent, str, body) =>
+        `${indent}items.<span class="idea-fn">append</span>(${str(body)})`,
+      replyQuote: (indent, comment, body) =>
+        `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
+      replyFillers: [
+        `    <span class="idea-kw">if</span> <span class="idea-kw">not</span> msg:`,
+        `        <span class="idea-kw">return</span>`,
+        `    ctx.<span class="idea-fn">touch</span>()`,
+        `    notes.<span class="idea-fn">sort</span>()`,
+        `    metrics.<span class="idea-fn">inc</span>(<span class="idea-str">"reply"</span>)`
+      ]
     }
   };
 
   function langStyle(product = getProduct()) {
-    if (product.id === "pycharm") {
-      return {
-        replyComment: "# ",
-        bodyComment: "    # ",
-        quoteComment: "# > "
-      };
-    }
-    return {
-      replyComment: "// ",
-      bodyComment: "  // ",
-      quoteComment: "// > "
-    };
+    return product.comment;
   }
 
   function getProductId() {
@@ -156,11 +416,26 @@
     } catch {
       /* ignore */
     }
-    return "idea";
+    return DEFAULT_PRODUCT_ID;
   }
 
   function getProduct() {
-    return PRODUCTS[getProductId()] || PRODUCTS.idea;
+    return PRODUCTS[getProductId()] || PRODUCTS[DEFAULT_PRODUCT_ID];
+  }
+
+  function nextProductId(id = getProductId()) {
+    const index = PRODUCT_ORDER.indexOf(id);
+    return PRODUCT_ORDER[(index + 1) % PRODUCT_ORDER.length];
+  }
+
+  function exportedIdent(stem) {
+    const cleaned = String(stem || "Topic") || "Topic";
+    if (/^[0-9]/.test(cleaned)) return `Topic_${cleaned}`;
+    return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+  }
+
+  function productNamesLabel() {
+    return PRODUCT_ORDER.map((id) => PRODUCTS[id].name).join(" / ");
   }
 
   function setProductId(id) {
@@ -177,7 +452,7 @@
     return `url("data:image/svg+xml,${encodeURIComponent(svg)}")`;
   }
 
-  const IDEA_SPLASH_BG = productSplashBg(PRODUCTS.idea);
+  const DEFAULT_SPLASH_BG = productSplashBg(PRODUCTS[DEFAULT_PRODUCT_ID]);
 
   const RAW_CSS = String.raw`
     /* Splash */
@@ -187,8 +462,8 @@
     }
 
     .idea-ide-theme #d-splash {
-      --dot-color: #4A9FD8 !important;
-      --splash-bg: ${IDEA_SPLASH_BG} !important;
+      --dot-color: #00D886 !important;
+      --splash-bg: ${DEFAULT_SPLASH_BG} !important;
       background: #2B2B2B !important;
     }
 
@@ -228,6 +503,8 @@
     .idea-ide-theme {
 
       color-scheme: light !important;
+      --idea-status-text: "UTF-8  ·  tabs  ·  Go  ·  Darcula  ·  Linux DO";
+      --idea-tab-icon: linear-gradient(135deg, #00D886, #007DFE);
       --idea-accent: #4A9FD8;
       --idea-accent-strong: #3592C4;
       --idea-accent-soft: #6CB2D9;
@@ -1677,13 +1954,9 @@
       width: 12px;
       height: 12px;
       border-radius: 2px;
-      background: linear-gradient(135deg, #CC7832, #6A8759);
+      background: var(--idea-tab-icon, linear-gradient(135deg, #00D886, #007DFE));
       box-shadow: inset 0 0 0 1px rgb(0 0 0 / 25%);
       flex: 0 0 auto;
-    }
-
-    .idea-product-pycharm.idea-ide-topic .idea-editor-tab-icon {
-      background: linear-gradient(135deg, #3572A5, #21D789);
     }
 
     .idea-ide-topic #topic-title,
@@ -1828,6 +2101,7 @@
       line-height: 20px;
       white-space: pre-wrap;
       word-break: break-word;
+      tab-size: 4;
     }
 
     .idea-ide-topic.idea-post-rows-themed .idea-code-line .idea-kw {
@@ -1995,7 +2269,7 @@
 
     /* Status bar */
     .idea-ide-theme #main-outlet::after {
-      content: "UTF-8  ·  4 spaces  ·  Java  ·  Darcula  ·  Linux DO";
+      content: var(--idea-status-text, "UTF-8  ·  tabs  ·  Go  ·  Darcula  ·  Linux DO");
       position: fixed;
       left: 0;
       right: 0;
@@ -2103,8 +2377,7 @@
   function onBrandClick(event) {
     event.preventDefault();
     event.stopPropagation();
-    const next = getProductId() === "pycharm" ? "idea" : "pycharm";
-    setProductId(next);
+    setProductId(nextProductId());
     invalidateProductBoundUi();
     applyTheme();
   }
@@ -2123,7 +2396,7 @@
     if (!brand) {
       brand = document.createElement("span");
       brand.className = "idea-brand";
-      brand.title = "点击切换 IntelliJ IDEA / PyCharm";
+      brand.title = `点击切换 ${productNamesLabel()}`;
       brand.addEventListener("click", onBrandClick);
       titleLink.appendChild(brand);
     }
@@ -2177,6 +2450,8 @@
       `<svg viewBox="0 0 16 16" aria-hidden="true"><text x="8" y="11.5" text-anchor="middle" font-size="9.5" font-weight="700" font-family="JetBrains Mono, Menlo, Consolas, monospace" fill="currentColor">M</text></svg>`,
     python: () =>
       `<svg viewBox="0 0 16 16" aria-hidden="true"><text x="8" y="11.5" text-anchor="middle" font-size="8" font-weight="700" font-family="JetBrains Mono, Menlo, Consolas, monospace" fill="currentColor">Py</text></svg>`,
+    go: () =>
+      `<svg viewBox="0 0 16 16" aria-hidden="true"><text x="8" y="11.5" text-anchor="middle" font-size="8" font-weight="700" font-family="JetBrains Mono, Menlo, Consolas, monospace" fill="currentColor">Go</text></svg>`,
     database: () =>
       `<svg viewBox="0 0 16 16" aria-hidden="true"><ellipse cx="8" cy="4" rx="5" ry="2" fill="none" stroke="currentColor" stroke-width="1.3"/><path d="M3 4v8c0 1.1 2.24 2 5 2s5-.9 5-2V4" fill="none" stroke="currentColor" stroke-width="1.3"/><path d="M3 8c0 1.1 2.24 2 5 2s5-.9 5-2" fill="none" stroke="currentColor" stroke-width="1.3"/></svg>`,
     ai: () =>
@@ -2310,20 +2585,20 @@
   }
 
   function sectionTreeLabel(sectionName) {
-    const isPy = getProductId() === "pycharm";
+    const aliases = getProduct().sidebarAliases || {};
     switch ((sectionName || "").toLowerCase()) {
       case "categories":
-        return isPy ? "src" : "directories";
+        return aliases.categories || "";
       case "tags":
-        return "packages";
+        return aliases.tags || "";
       case "chat-channels":
       case "chat-search":
-        return isPy ? "notebooks" : "resources";
+        return aliases.chat || "";
       case "chat-dms":
-        return "scratch";
+        return aliases.dms || "";
       default:
         if (sectionName === "资源" || /resource/i.test(sectionName)) {
-          return "externalLibraries";
+          return aliases.resources || "";
         }
         return "";
     }
@@ -2512,7 +2787,7 @@
       controls.prepend(button);
     }
 
-    button.textContent = getProductId() === "pycharm" ? "New File" : "New Class";
+    button.textContent = getProduct().newFileLabel;
 
     if (native && !native.dataset.ideaHidden) {
       native.dataset.ideaHidden = "1";
@@ -2537,7 +2812,7 @@
       document.title.replace(/\s*-\s*Linux DO.*$/i, "").trim() ||
       "untitled";
     const stem = sanitizeFileStem(title);
-    const leaf = product.id === "pycharm" ? `${stem}.${product.ext}` : title;
+    const leaf = product.breadcrumbFileLeaf ? `${stem}.${product.ext}` : title;
     const routeKey = `${product.id}|${location.pathname}|${leaf}`;
     if (bar.dataset.routeKey === routeKey) return;
     bar.dataset.routeKey = routeKey;
@@ -2714,52 +2989,27 @@
     return false;
   }
 
-  function createReplyPainter(productId) {
+  function createReplyPainter(product = getProduct()) {
     let seq = 0;
-    const isPy = productId === "pycharm";
-    const indent = isPy ? "    " : "  ";
+    const indent = product.indent;
+    const comment = product.comment.replyComment;
     const str = (body) => `<span class="idea-str">"${body}"</span>`;
-
-    const plainTemplates = isPy
-      ? [
-          (b) => `${indent}<span class="idea-fn">logger</span>.<span class="idea-fn">info</span>(${str(b)})`,
-          (b) => `${indent}notes.<span class="idea-fn">append</span>(${str(b)})`,
-          (b) => `${indent}<span class="idea-kw">assert</span> ${str(b)}`,
-          (b) => `${indent}ctx.<span class="idea-fn">reply</span>(${str(b)})`,
-          (b) => `${indent}msg = ${str(b)}`
-        ]
-      : [
-          (b) =>
-            `${indent}<span class="idea-fn">log</span>.<span class="idea-fn">info</span>(${str(b)});`,
-          (b) => `${indent}notes.<span class="idea-fn">add</span>(${str(b)});`,
-          (b) => `${indent}<span class="idea-kw">assert</span> ${str(b)}.<span class="idea-fn">length</span>() > 0;`,
-          (b) => `${indent}ctx.<span class="idea-fn">reply</span>(${str(b)});`,
-          (b) => `${indent}<span class="idea-kw">var</span> msg = ${str(b)};`
-        ];
-
-    const linkTemplate = isPy
-      ? (b) => `${indent}ctx.<span class="idea-fn">open</span>(${str(b)})`
-      : (b) => `${indent}ctx.<span class="idea-fn">open</span>(${str(b)});`;
-
-    const listTemplate = isPy
-      ? (b) => `${indent}items.<span class="idea-fn">append</span>(${str(b)})`
-      : (b) => `${indent}items.<span class="idea-fn">add</span>(${str(b)});`;
-
-    const quoteTemplate = isPy
-      ? (b) => `${indent}<span class="idea-cmt"># quoted: ${b}</span>`
-      : (b) => `${indent}<span class="idea-cmt">// quoted: ${b}</span>`;
+    const plainTemplates = product.replyPlain;
+    const linkTemplate = product.replyLink;
+    const listTemplate = product.replyList;
+    const quoteTemplate = product.replyQuote;
 
     function paint(body, kind = "plain") {
       const text = body || "";
-      if (kind === "link" || /<a\s/i.test(text)) return linkTemplate(text);
-      if (kind === "list") return listTemplate(text.replace(/^(\d+\.\s+|- )/, ""));
-      if (kind === "quote") return quoteTemplate(text);
+      if (kind === "link" || /<a\s/i.test(text)) return linkTemplate(indent, str, text);
+      if (kind === "list") return listTemplate(indent, str, text.replace(/^(\d+\.\s+|- )/, ""));
+      if (kind === "quote") return quoteTemplate(indent, comment, text);
       if (Array.from(text.replace(/<[^>]+>/g, "")).length <= 18) {
-        return plainTemplates[2](text); // short → assert
+        return plainTemplates[2](indent, str, text); // short → assert
       }
       const tpl = plainTemplates[seq % plainTemplates.length];
       seq += 1;
-      return tpl(text);
+      return tpl(indent, str, text);
     }
 
     return {
@@ -2782,9 +3032,9 @@
 
   function collectCookedLineHtml(cooked, asReply) {
     const lines = [];
-    const style = langStyle();
-    const productId = getProductId();
-    const painter = asReply ? createReplyPainter(productId) : null;
+    const product = getProduct();
+    const style = langStyle(product);
+    const painter = asReply ? createReplyPainter(product) : null;
     const commentPrefix = asReply ? style.replyComment : style.bodyComment;
 
     const appendBlocks = (root) => {
@@ -2864,16 +3114,14 @@
           const codeText = child.textContent || "";
           if (asReply) {
             lines.push(
-              productId === "pycharm"
-                ? `    <span class="idea-cmt"># snippet</span>`
-                : `  <span class="idea-cmt">// snippet</span>`
+              `${product.indent}<span class="idea-cmt">${product.comment.line} snippet</span>`
             );
           } else {
             lines.push(`<span class="idea-cmt">${commentPrefix}----- code -----</span>`);
           }
           for (const row of codeText.replace(/\r/g, "").split("\n")) {
             lines.push(
-              `${asReply ? (productId === "pycharm" ? "    " : "  ") : ""}` +
+              `${asReply ? product.indent : ""}` +
                 `<span class="idea-str">${escapeHtml(row)}</span>`
             );
           }
@@ -2893,32 +3141,16 @@
     if (!lines.length) {
       return asReply ? [painter.blank()] : [emptyComment];
     }
-    if (asReply) padShortReplyBody(lines, productId);
+    if (asReply) padShortReplyBody(lines, product);
     return lines;
   }
 
-  function padShortReplyBody(lines, productId) {
+  function padShortReplyBody(lines, product = getProduct()) {
     const MIN_BODY = 5;
     const bodyCount = lines.filter((l) => String(l || "").trim()).length;
     if (bodyCount >= MIN_BODY) return;
 
-    const isPy = productId === "pycharm";
-    const fillers = isPy
-      ? [
-          `    <span class="idea-kw">if</span> <span class="idea-kw">not</span> msg:`,
-          `        <span class="idea-kw">return</span>`,
-          `    ctx.<span class="idea-fn">touch</span>()`,
-          `    notes.<span class="idea-fn">sort</span>()`,
-          `    metrics.<span class="idea-fn">inc</span>(<span class="idea-str">"reply"</span>)`
-        ]
-      : [
-          `  <span class="idea-kw">if</span> (msg == <span class="idea-kw">null</span> || msg.<span class="idea-fn">isBlank</span>()) {`,
-          `    <span class="idea-kw">return</span>;`,
-          `  }`,
-          `  ctx.<span class="idea-fn">touch</span>();`,
-          `  notes.<span class="idea-fn">sort</span>(<span class="idea-kw">null</span>);`,
-          `  Metrics.<span class="idea-fn">inc</span>(<span class="idea-str">"reply"</span>);`
-        ];
+    const fillers = product.replyFillers;
 
     const seed = bodyCount + lines.join("").length;
     let i = seed % fillers.length;
@@ -2969,46 +3201,10 @@
     const time = getPostTimeText(post);
     const floor = getPostFloorLabel(post);
     const replyTo = getReplyToLabel(post);
-    const className = sanitizeFileStem(getTopicTitleText());
+    const stem = sanitizeFileStem(getTopicTitleText());
 
     if (postNumber === "1") {
-      if (product.id === "pycharm") {
-        return [
-          `<span class="idea-cmt">"""linux.do.topics</span>`,
-          ``,
-          `<span class="idea-cmt"><span class="idea-ann">@author</span> ${escapeHtml(name)}</span>`,
-          floor
-            ? `<span class="idea-cmt"><span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
-            : ``,
-          time
-            ? `<span class="idea-cmt"><span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
-            : ``,
-          `<span class="idea-cmt">"""</span>`,
-          ``,
-          `<span class="idea-kw">from</span> <span class="idea-str">community.discourse</span> <span class="idea-kw">import</span> *`,
-          ``,
-          `<span class="idea-kw">class</span> <span class="idea-fn">${escapeHtml(className)}</span>:`,
-          ``
-        ];
-      }
-
-      return [
-        `<span class="idea-kw">package</span> <span class="idea-str">linux.do.topics</span>;`,
-        ``,
-        `<span class="idea-kw">import</span> <span class="idea-str">community.discourse.*</span>;`,
-        ``,
-        `<span class="idea-cmt">/**</span>`,
-        `<span class="idea-cmt"> * <span class="idea-ann">@author</span> ${escapeHtml(name)}</span>`,
-        floor
-          ? `<span class="idea-cmt"> * <span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
-          : `<span class="idea-cmt"> *</span>`,
-        time
-          ? `<span class="idea-cmt"> * <span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
-          : `<span class="idea-cmt"> *</span>`,
-        `<span class="idea-cmt"> */</span>`,
-        `<span class="idea-kw">public class</span> <span class="idea-fn">${escapeHtml(className)}</span> {`,
-        ``
-      ];
+      return product.headerTopic({ name, floor, time, stem });
     }
 
     const methodName = `reply_${sanitizeFileStem(name) || "user"}_${postNumber}`.replace(
@@ -3023,33 +3219,14 @@
       .filter(Boolean)
       .join(" ");
 
-    if (product.id === "pycharm") {
-      return [
-        ``,
-        `<span class="idea-cmt"># ${escapeHtml(meta)}</span>`,
-        `<span class="idea-kw">def</span> <span class="idea-fn">${escapeHtml(methodName)}</span>():`
-      ];
-    }
-
-    return [
-      ``,
-      `<span class="idea-cmt">// ${escapeHtml(meta)}</span>`,
-      `<span class="idea-ann">@Reply</span>`,
-      `<span class="idea-kw">void</span> <span class="idea-fn">${escapeHtml(methodName)}</span>() {`
-    ];
+    return product.headerReply({ methodName, meta, name, floor, time, replyTo, postNumber });
   }
 
   function buildFooterLines(post) {
     const product = getProduct();
     const postNumber = post.getAttribute("data-post-number") || "?";
-    if (postNumber === "1") {
-      if (product.id === "pycharm") {
-        return [``, `<span class="idea-cmt"># end of topic</span>`];
-      }
-      return [``, `<span class="idea-kw">}</span> <span class="idea-cmt">// end of topic</span>`];
-    }
-    if (product.id === "pycharm") return [];
-    return [`<span class="idea-kw">}</span>`];
+    if (postNumber === "1") return product.footerTopic();
+    return product.footerReply();
   }
 
   function renderGutter(gutter, lineCount) {
@@ -3503,13 +3680,21 @@
     }
   }
 
+  function syncProductClasses(root = document.documentElement) {
+    const product = getProduct();
+    root.dataset.ideaProduct = product.id;
+    for (const id of Object.keys(PRODUCTS)) {
+      root.classList.toggle(`idea-product-${id}`, id === product.id);
+    }
+    root.style.setProperty("--idea-status-text", JSON.stringify(product.statusText));
+    root.style.setProperty("--idea-tab-icon", product.tabIcon);
+    return product;
+  }
+
   function applyTheme() {
     injectStyle();
     document.documentElement.classList.add("idea-ide-theme");
-    const product = getProduct();
-    document.documentElement.dataset.ideaProduct = product.id;
-    document.documentElement.classList.toggle("idea-product-idea", product.id === "idea");
-    document.documentElement.classList.toggle("idea-product-pycharm", product.id === "pycharm");
+    syncProductClasses();
     applyColorMode();
     restyleSplash();
     if (!document.body) return;
@@ -3581,10 +3766,7 @@
     );
     injectStyle();
     document.documentElement.classList.add("idea-ide-theme");
-    const bootProduct = getProduct();
-    document.documentElement.dataset.ideaProduct = bootProduct.id;
-    document.documentElement.classList.toggle("idea-product-idea", bootProduct.id === "idea");
-    document.documentElement.classList.toggle("idea-product-pycharm", bootProduct.id === "pycharm");
+    syncProductClasses();
     applyColorMode();
     restyleSplash();
 
@@ -3614,6 +3796,25 @@
     document.addEventListener("turbo:load", scheduleApply);
     document.addEventListener("page:changed", scheduleApply);
     scheduleApply();
+  }
+
+  if (globalThis.__LINUXDO_IDEA_EXPORT__) {
+    globalThis.__LINUXDO_IDEA__ = {
+      PRODUCTS,
+      PRODUCT_ORDER,
+      DEFAULT_PRODUCT_ID,
+      getProductId,
+      getProduct,
+      nextProductId,
+      setProductId,
+      langStyle,
+      exportedIdent,
+      sectionTreeLabel,
+      createReplyPainter,
+      padShortReplyBody,
+      buildHeaderLines,
+      buildFooterLines
+    };
   }
 
   bootstrap();

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -102,11 +102,12 @@
       indent: "\t",
       comment: {
         replyComment: "// ",
-        bodyComment: "\t// ",
+        bodyComment: "// ",
         quoteComment: "// > ",
         line: "//"
       },
-      statusText: "UTF-8  ·  tabs  ·  Go  ·  Darcula  ·  Linux DO",
+      paintReplyBody: "comment",
+      statusText: "UTF-8  ·  tabs  ·  Go 1.26  ·  Darcula  ·  Linux DO",
       statusLang: "Go",
       tabIcon: "linear-gradient(135deg, #00D886, #007DFE)",
       menus: [
@@ -140,59 +141,67 @@
         resources: "externalLibraries"
       },
       mark: GOLAND_MARK_SVG,
-      headerTopic({ name, floor, time, stem }) {
-        const ident = exportedIdent(stem);
+      headerTopic({ name, floor, time, title }) {
+        const topic = String(title || "").replace(/\s+/g, " ").trim() || "未命名话题";
+        const meta = [
+          name ? `作者 ${name}` : "",
+          floor ? `楼层 ${floor}` : "",
+          time ? `发表于 ${time}` : ""
+        ]
+          .filter(Boolean)
+          .join("，");
+        return [
+          `<span class="idea-cmt">// Package topics 记录「${escapeHtml(topic)}」。</span>`,
+          meta ? `<span class="idea-cmt">// ${escapeHtml(meta)}。</span>` : ``,
+          `<span class="idea-cmt">//</span>`
+        ];
+      },
+      headerReply({ name, floor, time, replyTo, postNumber }) {
+        const loc = floor || (postNumber ? `#${postNumber}` : "");
+        const bits = [
+          name && loc ? `${name} 的 ${loc} 楼` : name ? `${name} 的回复` : loc ? `${loc} 楼` : "",
+          time,
+          replyTo ? `回复 ${replyTo}` : ""
+        ]
+          .filter(Boolean)
+          .join("，");
         return [
           `<span class="idea-kw">package</span> topics`,
           ``,
-          `<span class="idea-kw">import</span> <span class="idea-str">"linux.do/community/discourse"</span>`,
-          ``,
-          `<span class="idea-cmt">// <span class="idea-ann">@author</span> ${escapeHtml(name)}</span>`,
-          floor
-            ? `<span class="idea-cmt">// <span class="idea-ann">@floor</span> ${escapeHtml(floor)}</span>`
-            : ``,
-          time
-            ? `<span class="idea-cmt">// <span class="idea-ann">@since</span> ${escapeHtml(time)}</span>`
-            : ``,
-          ``,
-          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(ident)}</span>() {`,
-          ``
+          bits ? `<span class="idea-cmt">// ${escapeHtml(bits)}。</span>` : ``
         ];
       },
-      headerReply({ methodName, meta }) {
-        return [
+      footerTopic({ name, floor, time, postNumber }) {
+        const n = goFloorNumber(floor, postNumber);
+        const lines = [
+          `<span class="idea-kw">package</span> topics`,
           ``,
-          `<span class="idea-cmt">// ${escapeHtml(meta)}</span>`,
-          `<span class="idea-kw">func</span> <span class="idea-fn">${escapeHtml(methodName)}</span>() {`
+          `<span class="idea-kw">type</span> <span class="idea-fn">Post</span> <span class="idea-kw">struct</span> {`,
+          `\tAuthor, At, ReplyTo <span class="idea-kw">string</span>`,
+          `\tFloor               <span class="idea-kw">int</span>`,
+          `}`,
+          ``,
+          `<span class="idea-kw">var</span> Topic = <span class="idea-fn">Post</span>{`,
+          `\tAuthor: ${goStringLiteral(name || "")},`,
+          `\tFloor:  ${escapeHtml(n)},`
         ];
+        if (time) lines.push(`\tAt:     ${goStringLiteral(time)},`);
+        lines.push(`}`);
+        return lines;
       },
-      footerTopic() {
-        return [``, `<span class="idea-kw">}</span> <span class="idea-cmt">// end of topic</span>`];
-      },
-      footerReply() {
-        return [`<span class="idea-kw">}</span>`];
-      },
-      replyPlain: [
-        (indent, str, body) =>
-          `${indent}<span class="idea-fn">log</span>.<span class="idea-fn">Printf</span>(<span class="idea-str">"%s"</span>, ${str(body)})`,
-        (indent, str, body) =>
-          `${indent}notes = <span class="idea-fn">append</span>(notes, ${str(body)})`,
-        (indent, str, body) =>
-          `${indent}<span class="idea-kw">if</span> ${str(body)} == <span class="idea-str">""</span> { <span class="idea-kw">return</span> }`,
-        (indent, str, body) => `${indent}ctx.<span class="idea-fn">Reply</span>(${str(body)})`,
-        (indent, str, body) => `${indent}msg := ${str(body)}`
-      ],
-      replyLink: (indent, str, body) => `${indent}ctx.<span class="idea-fn">Open</span>(${str(body)})`,
-      replyList: (indent, str, body) =>
-        `${indent}items = <span class="idea-fn">append</span>(items, ${str(body)})`,
-      replyQuote: (indent, comment, body) =>
-        `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
-      replyFillers: [
-        `\t<span class="idea-kw">if</span> msg == <span class="idea-str">""</span> { <span class="idea-kw">return</span> }`,
-        `\tctx.<span class="idea-fn">Touch</span>()`,
-        `\tsort.<span class="idea-fn">Strings</span>(notes)`,
-        `\tmetrics.<span class="idea-fn">Inc</span>(<span class="idea-str">"reply"</span>)`
-      ]
+      footerReply({ name, floor, time, replyTo, postNumber }) {
+        const ident = goPostIdent(name, postNumber);
+        const n = goFloorNumber(floor, postNumber);
+        const lines = [
+          `<span class="idea-kw">var</span> ${escapeHtml(ident)} = <span class="idea-fn">Post</span>{`,
+          `\tAuthor: ${goStringLiteral(name || "anon")},`,
+          `\tFloor:  ${escapeHtml(n)},`
+        ];
+        if (time) lines.push(`\tAt:     ${goStringLiteral(time)},`);
+        if (replyTo) lines.push(`\tReplyTo: ${goStringLiteral(replyTo)},`);
+        lines.push(`}`);
+        return lines;
+      }
     },
     idea: {
       id: "idea",
@@ -429,9 +438,58 @@
   }
 
   function exportedIdent(stem) {
-    const cleaned = String(stem || "Topic") || "Topic";
-    if (/^[0-9]/.test(cleaned)) return `Topic_${cleaned}`;
-    return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
+    return goIdent(stem, { fallback: "Topic", exported: true });
+  }
+
+  function goIdent(text, { fallback = "Topic", exported = false } = {}) {
+    let out = "";
+    for (const ch of Array.from(String(text || ""))) {
+      if (/^[\p{L}\p{Nd}_]$/u.test(ch)) out += ch;
+      else if (out && !out.endsWith("_")) out += "_";
+    }
+    out = out.replace(/_+/g, "_").replace(/^_|_$/g, "");
+    if (!out) return fallback;
+    if (/^\p{Nd}/u.test(out)) return `${fallback}_${out}`;
+    if (exported && /^[a-z]$/.test(out.charAt(0))) {
+      return out.charAt(0).toUpperCase() + out.slice(1);
+    }
+    return out;
+  }
+
+  function goPostIdent(name, postNumber) {
+    const who = goIdent(name, { fallback: "anon" });
+    const num = goFloorNumber("", postNumber);
+    return `${who}_${num}`;
+  }
+
+  function goFloorNumber(floor, postNumber) {
+    const n = String(floor || postNumber || "").replace(/[^\p{Nd}]/gu, "");
+    return n || "0";
+  }
+
+  function stripHtmlToText(htmlOrText) {
+    return String(htmlOrText || "")
+      .replace(/<[^>]+>/g, "")
+      .replace(/&nbsp;/gi, " ")
+      .replace(/&quot;/gi, "\"")
+      .replace(/&#39;|&apos;/gi, "'")
+      .replace(/&lt;/gi, "<")
+      .replace(/&gt;/gi, ">")
+      .replace(/&amp;/gi, "&");
+  }
+
+  function goStringLiteral(htmlOrText) {
+    const plain = stripHtmlToText(htmlOrText);
+    let escaped = "";
+    for (const ch of plain) {
+      if (ch === "\\") escaped += "\\\\";
+      else if (ch === "\"") escaped += "\\\"";
+      else if (ch === "\n") escaped += "\\n";
+      else if (ch === "\r") escaped += "\\r";
+      else if (ch === "\t") escaped += "\\t";
+      else escaped += ch;
+    }
+    return `<span class="idea-str">"${escapeHtml(escaped)}"</span>`;
   }
 
   function productNamesLabel() {
@@ -503,7 +561,7 @@
     .idea-ide-theme {
 
       color-scheme: light !important;
-      --idea-status-text: "UTF-8  ·  tabs  ·  Go  ·  Darcula  ·  Linux DO";
+      --idea-status-text: "UTF-8  ·  tabs  ·  Go 1.26  ·  Darcula  ·  Linux DO";
       --idea-tab-icon: linear-gradient(135deg, #00D886, #007DFE);
       --idea-accent: #4A9FD8;
       --idea-accent-strong: #3592C4;
@@ -2269,7 +2327,7 @@
 
     /* Status bar */
     .idea-ide-theme #main-outlet::after {
-      content: var(--idea-status-text, "UTF-8  ·  tabs  ·  Go  ·  Darcula  ·  Linux DO");
+      content: var(--idea-status-text, "UTF-8  ·  tabs  ·  Go 1.26  ·  Darcula  ·  Linux DO");
       position: fixed;
       left: 0;
       right: 0;
@@ -2993,7 +3051,8 @@
     let seq = 0;
     const indent = product.indent;
     const comment = product.comment.replyComment;
-    const str = (body) => `<span class="idea-str">"${body}"</span>`;
+    const str =
+      product.quoteString || ((body) => `<span class="idea-str">"${body}"</span>`);
     const plainTemplates = product.replyPlain;
     const linkTemplate = product.replyLink;
     const listTemplate = product.replyList;
@@ -3151,6 +3210,7 @@
     if (bodyCount >= MIN_BODY) return;
 
     const fillers = product.replyFillers;
+    if (!fillers || !fillers.length) return;
 
     const seed = bodyCount + lines.join("").length;
     let i = seed % fillers.length;
@@ -3187,10 +3247,14 @@
     return floor;
   }
 
-  function getReplyToLabel(post) {
+  function getReplyToName(post) {
     const tab = post.querySelector(".topic-meta-data .reply-to-tab, .reply-to-tab");
     if (!tab) return "";
-    const name = tab.querySelector("span")?.textContent?.trim() || "";
+    return tab.querySelector("span")?.textContent?.trim() || "";
+  }
+
+  function getReplyToLabel(post) {
+    const name = getReplyToName(post);
     return name ? `reply-to ${name}` : "";
   }
 
@@ -3200,11 +3264,13 @@
     const name = getPostAuthorName(post);
     const time = getPostTimeText(post);
     const floor = getPostFloorLabel(post);
-    const replyTo = getReplyToLabel(post);
-    const stem = sanitizeFileStem(getTopicTitleText());
+    const replyToName = getReplyToName(post);
+    const replyTo = replyToName ? `reply-to ${replyToName}` : "";
+    const title = getTopicTitleText();
+    const stem = sanitizeFileStem(title);
 
     if (postNumber === "1") {
-      return product.headerTopic({ name, floor, time, stem });
+      return product.headerTopic({ name, floor, time, stem, title });
     }
 
     const methodName = `reply_${sanitizeFileStem(name) || "user"}_${postNumber}`.replace(
@@ -3219,14 +3285,29 @@
       .filter(Boolean)
       .join(" ");
 
-    return product.headerReply({ methodName, meta, name, floor, time, replyTo, postNumber });
+    return product.headerReply({
+      methodName,
+      meta,
+      name,
+      floor,
+      time,
+      replyTo: replyToName,
+      postNumber
+    });
   }
 
   function buildFooterLines(post) {
     const product = getProduct();
     const postNumber = post.getAttribute("data-post-number") || "?";
-    if (postNumber === "1") return product.footerTopic();
-    return product.footerReply();
+    const ctx = {
+      name: getPostAuthorName(post),
+      time: getPostTimeText(post),
+      floor: getPostFloorLabel(post),
+      replyTo: getReplyToName(post),
+      postNumber
+    };
+    if (postNumber === "1") return product.footerTopic(ctx);
+    return product.footerReply(ctx);
   }
 
   function renderGutter(gutter, lineCount) {
@@ -3277,13 +3358,14 @@
       if (!gutter || !codeLines) continue;
 
       const isReply = (post.getAttribute("data-post-number") || "1") !== "1";
+      const paintReplyAsCode = isReply && getProduct().paintReplyBody !== "comment";
       const allLines = [
         ...buildHeaderLines(post),
-        ...collectCookedLineHtml(cooked, isReply),
+        ...collectCookedLineHtml(cooked, paintReplyAsCode),
         ...buildFooterLines(post)
       ];
 
-      const signature = `v6:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v7:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -3809,6 +3891,9 @@
       setProductId,
       langStyle,
       exportedIdent,
+      goIdent,
+      goPostIdent,
+      goStringLiteral,
       sectionTreeLabel,
       createReplyPainter,
       padShortReplyBody,

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -200,8 +200,8 @@
       replyLink: (indent, str, body) => `${indent}ctx.<span class="idea-fn">Open</span>(${str(body)})`,
       replyList: (indent, str, body) =>
         `${indent}items = <span class="idea-fn">append</span>(items, ${str(body)})`,
-      replyQuote: (indent, comment, body) =>
-        `${indent}<span class="idea-cmt">${comment}quoted: ${body}</span>`,
+      replyQuote: (indent, _comment, body) => goReplyQuoteBlock(indent, "", body),
+      replyQuoteBlock: goReplyQuoteBlock,
       replyFillers: []
     },
     idea: {
@@ -556,6 +556,17 @@
 
   function goPrintlnStatement(indent, str, body) {
     return `${indent}<span class="idea-fn">println</span>(${str(body)})`;
+  }
+
+  function goReplyQuoteBlock(indent, who, text) {
+    const whoPlain = stripHtmlToText(who).trim();
+    const textPlain = stripHtmlToText(text).trim();
+    const textRaw = goQuoteHtmlAsRawString(escapeHtml(textPlain));
+    if (whoPlain) {
+      const whoRaw = goQuoteHtmlAsRawString(escapeHtml(whoPlain));
+      return `${indent}<span class="idea-fn">quote</span>.<span class="idea-fn">From</span>(${whoRaw}, ${textRaw})`;
+    }
+    return `${indent}<span class="idea-fn">quote</span>.<span class="idea-fn">From</span>(${textRaw})`;
   }
 
   function goBodyFieldLines(text, indent = "\t") {
@@ -3292,6 +3303,32 @@
     return false;
   }
 
+  function isDiscourseQuoteBlock(node) {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) return false;
+    if (node.matches?.("aside.quote, aside[data-username]")) return true;
+    if (node.classList?.contains("quote") && node.querySelector?.(":scope > blockquote, blockquote")) {
+      return true;
+    }
+    return false;
+  }
+
+  function extractDiscourseQuote(node) {
+    const whoRaw =
+      node.getAttribute?.("data-username") ||
+      node.querySelector?.(".title")?.textContent ||
+      "";
+    const who = String(whoRaw)
+      .replace(/\u00a0/g, " ")
+      .replace(/\s+/g, " ")
+      .trim()
+      .replace(/[:：]\s*$/, "");
+    const body = String(node.querySelector?.("blockquote")?.textContent || "")
+      .replace(/\u00a0/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+    return { who, body };
+  }
+
   function createReplyPainter(product = getProduct()) {
     let seq = 0;
     const indent = product.indent;
@@ -3362,6 +3399,23 @@
         const tag = child.tagName.toLowerCase();
         if (tag === "br") {
           if (!asReply) lines.push(`<span class="idea-cmt">${commentPrefix.trimEnd()}</span>`);
+          continue;
+        }
+
+        if (isDiscourseQuoteBlock(child)) {
+          const { who, body } = extractDiscourseQuote(child);
+          if (!who && !body) continue;
+          if (asReply) {
+            if (typeof product.replyQuoteBlock === "function") {
+              lines.push(product.replyQuoteBlock(product.indent, who, body));
+            } else {
+              const payload = who ? `${escapeHtml(who)}: ${escapeHtml(body)}` : escapeHtml(body);
+              painter.pushText(lines, payload, "quote");
+            }
+          } else {
+            const commentText = who && body ? `${who}: ${body}` : who || body;
+            pushCommentLines(lines, commentText, style.quoteComment);
+          }
           continue;
         }
 
@@ -3626,7 +3680,7 @@
         ...buildFooterLines(post)
       ];
 
-      const signature = `v15:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v16:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -4164,6 +4218,9 @@
       isDiscourseImageCaption,
       collectCookedBodySegments,
       collectCookedImageLines,
+      isDiscourseQuoteBlock,
+      extractDiscourseQuote,
+      goReplyQuoteBlock,
       buildImageCodeLine,
       sectionTreeLabel,
       createReplyPainter,

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -532,21 +532,14 @@
 
   function cookedToGoBody(cooked) {
     if (!cooked) return "";
-    const extras = [];
-    for (const img of cooked.querySelectorAll?.("img") || []) {
-      const src = getImageSrc(img);
-      if (src) extras.push(`[image] ${src}`);
-    }
     let text = "";
     if (typeof cooked.innerText === "string" && cooked.innerText) text = cooked.innerText;
     else text = cooked.textContent || "";
-    text = String(text)
+    return String(text)
       .replace(/\u00a0/g, " ")
       .replace(/\r/g, "")
       .replace(/[ \t]+\n/g, "\n")
       .trim();
-    if (extras.length) text = text ? `${text}\n\n${extras.join("\n")}` : extras.join("\n");
-    return text;
   }
 
   function productNamesLabel() {
@@ -3095,6 +3088,13 @@
     return count;
   }
 
+  function collectCookedImageLines(cooked, prefix = "// ") {
+    const lines = [];
+    if (!cooked) return lines;
+    pushImageNodes(lines, cooked, prefix);
+    return lines;
+  }
+
   function isImageContainer(node) {
     if (!node || node.nodeType !== Node.ELEMENT_NODE) return false;
     const tag = node.tagName.toLowerCase();
@@ -3419,13 +3419,15 @@
       const product = getProduct();
       const embedBody = product.paintBody === "raw-string";
       const paintReplyAsCode = isReply && !embedBody;
+      const imageLines = embedBody ? collectCookedImageLines(cooked, "// ") : [];
       const allLines = [
         ...buildHeaderLines(post),
         ...(embedBody ? [] : collectCookedLineHtml(cooked, paintReplyAsCode)),
-        ...buildFooterLines(post)
+        ...buildFooterLines(post),
+        ...(imageLines.length ? ["", ...imageLines] : [])
       ];
 
-      const signature = `v8:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v9:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -3957,6 +3959,8 @@
       goRawStringDisplayLines,
       goBodyFieldLines,
       cookedToGoBody,
+      collectCookedImageLines,
+      buildImageCodeLine,
       sectionTreeLabel,
       createReplyPainter,
       padShortReplyBody,

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -141,7 +141,7 @@
         resources: "externalLibraries"
       },
       mark: GOLAND_MARK_SVG,
-      headerTopic({ name, floor, time, title, postNumber }) {
+      headerTopic({ name, floor, time, title, postNumber, cooked }) {
         const topic = String(title || "").replace(/\s+/g, " ").trim() || "未命名话题";
         const n = goFloorNumber(floor, postNumber);
         const meta = [
@@ -156,6 +156,10 @@
         ];
         if (meta) lines.push(`<span class="idea-cmt">// ${escapeHtml(meta)}。</span>`);
         lines.push(`<span class="idea-kw">package</span> topics`);
+        if (cookedHasImages(cooked)) {
+          lines.push(``);
+          lines.push(`<span class="idea-kw">import</span> <span class="idea-str">"fmt"</span>`);
+        }
         return lines;
       },
       headerReply({ name, floor, time, replyTo, postNumber }) {
@@ -680,38 +684,48 @@
     return segments;
   }
 
+  function cookedHasImages(cooked) {
+    return collectCookedBodySegments(cooked).some((seg) => seg.kind === "image");
+  }
+
+  function goEscapeFmtPercent(text) {
+    return String(text ?? "").replace(/%/g, "%%");
+  }
+
+  function goImageSprintfArgLine(src, indent) {
+    const safeSrc = escapeHtml(src || "");
+    return (
+      `${indent}${goStringLiteral(src)}, ` +
+      `<span class="idea-cmt">// [image]</span>` +
+      `<img class="idea-code-image-preview" data-src="${safeSrc}" alt="">`
+    );
+  }
+
   function goBodyFieldLinesFromCooked(cooked, indent = "\t", fallback = "") {
     if (!cooked) return goBodyFieldLines(fallback, indent);
     const segments = collectCookedBodySegments(cooked);
-    if (!segments.some((seg) => seg.kind === "image")) {
+    const images = segments.filter((seg) => seg.kind === "image");
+    if (!images.length) {
       return goBodyFieldLines(cookedToGoBody(cooked) || fallback, indent);
     }
 
-    const parts = segments.slice();
-    if (parts[0].kind === "image") parts.unshift({ kind: "text", text: "" });
-    if (parts[parts.length - 1].kind === "image") parts.push({ kind: "text", text: "" });
-
+    const formatText = segments
+      .map((seg) => (seg.kind === "image" ? "%s" : goEscapeFmtPercent(seg.text)))
+      .join("\n");
+    const rawLines = goRawStringDisplayLines(formatText);
+    const fmtCall = `fmt.<span class="idea-fn">Sprintf</span>(`;
     const lines = [];
-    let textIndex = 0;
-    const textCount = parts.filter((seg) => seg.kind === "text").length;
-    for (const seg of parts) {
-      if (seg.kind === "image") {
-        lines.push(`${indent}${buildImageCodeLine("// ", seg.src)}`);
-        continue;
+    if (rawLines.length === 1) {
+      lines.push(`${indent}Body: ${fmtCall}${rawLines[0]},`);
+    } else {
+      lines.push(`${indent}Body: ${fmtCall}${rawLines[0]}`);
+      for (let i = 1; i < rawLines.length; i += 1) {
+        lines.push(i === rawLines.length - 1 ? `${rawLines[i]},` : rawLines[i]);
       }
-      const prefix = textIndex === 0 ? `${indent}Body: ` : indent;
-      const suffix = textIndex === textCount - 1 ? "," : " +";
-      const rawLines = goRawStringDisplayLines(seg.text);
-      if (rawLines.length === 1) {
-        lines.push(`${prefix}${rawLines[0]}${suffix}`);
-      } else {
-        lines.push(`${prefix}${rawLines[0]}`);
-        for (let i = 1; i < rawLines.length; i += 1) {
-          lines.push(i === rawLines.length - 1 ? `${rawLines[i]}${suffix}` : rawLines[i]);
-        }
-      }
-      textIndex += 1;
     }
+    const argIndent = `${indent}\t`;
+    for (const img of images) lines.push(goImageSprintfArgLine(img.src, argIndent));
+    lines.push(`${indent}),`);
     return lines;
   }
 
@@ -3512,7 +3526,15 @@
     const stem = sanitizeFileStem(title);
 
     if (postNumber === "1") {
-      return product.headerTopic({ name, floor, time, stem, title, postNumber });
+      return product.headerTopic({
+        name,
+        floor,
+        time,
+        stem,
+        title,
+        postNumber,
+        cooked: post.querySelector(".cooked")
+      });
     }
 
     const methodName = `reply_${sanitizeFileStem(name) || "user"}_${postNumber}`.replace(
@@ -3612,7 +3634,7 @@
         ...buildFooterLines(post)
       ];
 
-      const signature = `v10:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v11:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -4144,6 +4166,8 @@
       goRawStringDisplayLines,
       goBodyFieldLines,
       goBodyFieldLinesFromCooked,
+      cookedHasImages,
+      goEscapeFmtPercent,
       cookedToGoBody,
       leftoverCookedText,
       isDiscourseImageCaption,

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -106,7 +106,7 @@
         quoteComment: "// > ",
         line: "//"
       },
-      paintReplyBody: "comment",
+      paintBody: "raw-string",
       statusText: "UTF-8  ·  tabs  ·  Go 1.26  ·  Darcula  ·  Linux DO",
       statusLang: "Go",
       tabIcon: "linear-gradient(135deg, #00D886, #007DFE)",
@@ -141,25 +141,27 @@
         resources: "externalLibraries"
       },
       mark: GOLAND_MARK_SVG,
-      headerTopic({ name, floor, time, title }) {
+      headerTopic({ name, floor, time, title, postNumber }) {
         const topic = String(title || "").replace(/\s+/g, " ").trim() || "未命名话题";
+        const n = goFloorNumber(floor, postNumber);
         const meta = [
           name ? `作者 ${name}` : "",
-          floor ? `楼层 ${floor}` : "",
+          n ? `楼层 ${n}` : "",
           time ? `发表于 ${time}` : ""
         ]
           .filter(Boolean)
           .join("，");
-        return [
-          `<span class="idea-cmt">// Package topics 记录「${escapeHtml(topic)}」。</span>`,
-          meta ? `<span class="idea-cmt">// ${escapeHtml(meta)}。</span>` : ``,
-          `<span class="idea-cmt">//</span>`
+        const lines = [
+          `<span class="idea-cmt">// Package topics 记录「${escapeHtml(topic)}」。</span>`
         ];
+        if (meta) lines.push(`<span class="idea-cmt">// ${escapeHtml(meta)}。</span>`);
+        lines.push(`<span class="idea-kw">package</span> topics`);
+        return lines;
       },
       headerReply({ name, floor, time, replyTo, postNumber }) {
-        const loc = floor || (postNumber ? `#${postNumber}` : "");
+        const n = goFloorNumber(floor, postNumber);
         const bits = [
-          name && loc ? `${name} 的 ${loc} 楼` : name ? `${name} 的回复` : loc ? `${loc} 楼` : "",
+          name ? `${name} 的 ${n} 楼` : `${n} 楼`,
           time,
           replyTo ? `回复 ${replyTo}` : ""
         ]
@@ -171,36 +173,35 @@
           bits ? `<span class="idea-cmt">// ${escapeHtml(bits)}。</span>` : ``
         ];
       },
-      footerTopic({ name, floor, time, postNumber }) {
+      footerTopic({ name, floor, time, postNumber, body }) {
         const n = goFloorNumber(floor, postNumber);
-        const lines = [
-          `<span class="idea-kw">package</span> topics`,
+        return [
           ``,
           `<span class="idea-kw">type</span> <span class="idea-fn">Post</span> <span class="idea-kw">struct</span> {`,
-          `\tAuthor, At, ReplyTo <span class="idea-kw">string</span>`,
-          `\tFloor               <span class="idea-kw">int</span>`,
+          `\tAuthor, At, ReplyTo, Body <span class="idea-kw">string</span>`,
+          `\tFloor                     <span class="idea-kw">int</span>`,
           `}`,
           ``,
           `<span class="idea-kw">var</span> Topic = <span class="idea-fn">Post</span>{`,
           `\tAuthor: ${goStringLiteral(name || "")},`,
-          `\tFloor:  ${escapeHtml(n)},`
+          `\tFloor:  ${escapeHtml(n)},`,
+          ...(time ? [`\tAt:     ${goStringLiteral(time)},`] : []),
+          ...goBodyFieldLines(body),
+          `}`
         ];
-        if (time) lines.push(`\tAt:     ${goStringLiteral(time)},`);
-        lines.push(`}`);
-        return lines;
       },
-      footerReply({ name, floor, time, replyTo, postNumber }) {
+      footerReply({ name, floor, time, replyTo, postNumber, body }) {
         const ident = goPostIdent(name, postNumber);
         const n = goFloorNumber(floor, postNumber);
-        const lines = [
+        return [
           `<span class="idea-kw">var</span> ${escapeHtml(ident)} = <span class="idea-fn">Post</span>{`,
-          `\tAuthor: ${goStringLiteral(name || "anon")},`,
-          `\tFloor:  ${escapeHtml(n)},`
+          `\tAuthor:  ${goStringLiteral(name || "anon")},`,
+          `\tFloor:   ${escapeHtml(n)},`,
+          ...(time ? [`\tAt:      ${goStringLiteral(time)},`] : []),
+          ...(replyTo ? [`\tReplyTo: ${goStringLiteral(replyTo)},`] : []),
+          ...goBodyFieldLines(body),
+          `}`
         ];
-        if (time) lines.push(`\tAt:     ${goStringLiteral(time)},`);
-        if (replyTo) lines.push(`\tReplyTo: ${goStringLiteral(replyTo)},`);
-        lines.push(`}`);
-        return lines;
       }
     },
     idea: {
@@ -490,6 +491,64 @@
       else escaped += ch;
     }
     return `<span class="idea-str">"${escapeHtml(escaped)}"</span>`;
+  }
+
+  function goRawStringDisplayLines(text) {
+    const parts = String(text ?? "").split("`");
+    if (parts.length === 1) {
+      const rows = parts[0].split("\n");
+      return rows.map((row, i) => {
+        const open = i === 0 ? `<span class="idea-str">\`` : `<span class="idea-str">`;
+        const close = i === rows.length - 1 ? `\`</span>` : `</span>`;
+        return `${open}${escapeHtml(row)}${close}`;
+      });
+    }
+    const pieces = [];
+    for (let i = 0; i < parts.length; i += 1) {
+      if (parts[i] !== "") {
+        const rows = parts[i].split("\n");
+        pieces.push(
+          rows
+            .map((row, li) => {
+              const open = li === 0 ? `<span class="idea-str">\`` : `<span class="idea-str">`;
+              const close = li === rows.length - 1 ? `\`</span>` : `</span>`;
+              return `${open}${escapeHtml(row)}${close}`;
+            })
+            .join("\n")
+        );
+      }
+      if (i < parts.length - 1) pieces.push(`<span class="idea-str">"\`"</span>`);
+    }
+    return (pieces.join(" + ") || `<span class="idea-str">\`\`</span>`).split("\n");
+  }
+
+  function goBodyFieldLines(text) {
+    const rawLines = goRawStringDisplayLines(text);
+    if (rawLines.length === 1) return [`\tBody: ${rawLines[0]},`];
+    const lines = [`\tBody: ${rawLines[0]}`];
+    for (let i = 1; i < rawLines.length; i += 1) {
+      lines.push(i === rawLines.length - 1 ? `${rawLines[i]},` : rawLines[i]);
+    }
+    return lines;
+  }
+
+  function cookedToGoBody(cooked) {
+    if (!cooked) return "";
+    const extras = [];
+    for (const img of cooked.querySelectorAll?.("img") || []) {
+      const src = getImageSrc(img);
+      if (src) extras.push(`[image] ${src}`);
+    }
+    let text = "";
+    if (typeof cooked.innerText === "string" && cooked.innerText) text = cooked.innerText;
+    else text = cooked.textContent || "";
+    text = String(text)
+      .replace(/\u00a0/g, " ")
+      .replace(/\r/g, "")
+      .replace(/[ \t]+\n/g, "\n")
+      .trim();
+    if (extras.length) text = text ? `${text}\n\n${extras.join("\n")}` : extras.join("\n");
+    return text;
   }
 
   function productNamesLabel() {
@@ -3270,7 +3329,7 @@
     const stem = sanitizeFileStem(title);
 
     if (postNumber === "1") {
-      return product.headerTopic({ name, floor, time, stem, title });
+      return product.headerTopic({ name, floor, time, stem, title, postNumber });
     }
 
     const methodName = `reply_${sanitizeFileStem(name) || "user"}_${postNumber}`.replace(
@@ -3304,7 +3363,8 @@
       time: getPostTimeText(post),
       floor: getPostFloorLabel(post),
       replyTo: getReplyToName(post),
-      postNumber
+      postNumber,
+      body: product.paintBody === "raw-string" ? cookedToGoBody(post.querySelector(".cooked")) : ""
     };
     if (postNumber === "1") return product.footerTopic(ctx);
     return product.footerReply(ctx);
@@ -3358,14 +3418,16 @@
       if (!gutter || !codeLines) continue;
 
       const isReply = (post.getAttribute("data-post-number") || "1") !== "1";
-      const paintReplyAsCode = isReply && getProduct().paintReplyBody !== "comment";
+      const product = getProduct();
+      const embedBody = product.paintBody === "raw-string";
+      const paintReplyAsCode = isReply && !embedBody;
       const allLines = [
         ...buildHeaderLines(post),
-        ...collectCookedLineHtml(cooked, paintReplyAsCode),
+        ...(embedBody ? [] : collectCookedLineHtml(cooked, paintReplyAsCode)),
         ...buildFooterLines(post)
       ];
 
-      const signature = `v7:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v8:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -3894,6 +3956,9 @@
       goIdent,
       goPostIdent,
       goStringLiteral,
+      goRawStringDisplayLines,
+      goBodyFieldLines,
+      cookedToGoBody,
       sectionTreeLabel,
       createReplyPainter,
       padShortReplyBody,

--- a/linuxdo-idea.user.js
+++ b/linuxdo-idea.user.js
@@ -169,7 +169,7 @@
           .join("，");
         return bits ? [`<span class="idea-cmt">// ${escapeHtml(bits)}。</span>`] : [];
       },
-      footerTopic({ name, floor, time, postNumber, body }) {
+      footerTopic({ name, floor, time, postNumber, body, cooked }) {
         const n = goFloorNumber(floor, postNumber);
         return [
           ``,
@@ -182,11 +182,11 @@
           `\tAuthor: ${goStringLiteral(name || "")},`,
           `\tFloor:  ${escapeHtml(n)},`,
           ...(time ? [`\tAt:     ${goStringLiteral(time)},`] : []),
-          ...goBodyFieldLines(body),
+          ...goBodyFieldLinesFromCooked(cooked, "\t", body),
           `}`
         ];
       },
-      footerReply({ name, floor, time, replyTo, postNumber, body }) {
+      footerReply({ name, floor, time, replyTo, postNumber, body, cooked }) {
         const ident = goPostIdent(name, postNumber);
         const n = goFloorNumber(floor, postNumber);
         return [
@@ -196,7 +196,7 @@
           `\t\tFloor:   ${escapeHtml(n)},`,
           ...(time ? [`\t\tAt:      ${goStringLiteral(time)},`] : []),
           ...(replyTo ? [`\t\tReplyTo: ${goStringLiteral(replyTo)},`] : []),
-          ...goBodyFieldLines(body, "\t\t"),
+          ...goBodyFieldLinesFromCooked(cooked, "\t\t", body),
           `\t}`,
           `}`
         ];
@@ -526,6 +526,191 @@
     const lines = [`${indent}Body: ${rawLines[0]}`];
     for (let i = 1; i < rawLines.length; i += 1) {
       lines.push(i === rawLines.length - 1 ? `${rawLines[i]},` : rawLines[i]);
+    }
+    return lines;
+  }
+
+  function leftoverCookedText(node) {
+    if (!node || node.nodeType !== Node.ELEMENT_NODE) return "";
+    const clone = node.cloneNode(true);
+    for (const img of clone.querySelectorAll?.("img") || []) img.remove();
+    for (const a of clone.querySelectorAll?.("a.lightbox") || []) a.remove();
+    return String(clone.textContent || "")
+      .replace(/\u00a0/g, " ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function isDiscourseImageCaption(text) {
+    const t = String(text || "").replace(/\s+/g, " ").trim();
+    if (!t) return true;
+    const hasDims = /\d+\s*[×xX]\s*\d+/.test(t);
+    const hasSize = /\d+(?:\.\d+)?\s*[KMGT]?B\b/i.test(t);
+    if (hasDims && hasSize) return true;
+    if (/^PixPin_\d{4}-\d{2}-\d{2}/i.test(t)) return true;
+    if (/^[\w.-]+\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(t) && t.length < 80) return true;
+    return false;
+  }
+
+  function cookedNodePlainText(node) {
+    if (!node) return "";
+    let text = "";
+    if (node.nodeType === Node.TEXT_NODE) text = node.nodeValue || "";
+    else if (typeof node.innerText === "string" && node.innerText) text = node.innerText;
+    else text = node.textContent || "";
+    return String(text)
+      .replace(/\u00a0/g, " ")
+      .replace(/\r/g, "")
+      .replace(/[ \t]+\n/g, "\n")
+      .trim();
+  }
+
+  function collectCookedBodySegments(cooked) {
+    const segments = [];
+    if (!cooked) return segments;
+
+    function normalizeBodyText(text) {
+      return String(text ?? "")
+        .replace(/\u00a0/g, " ")
+        .replace(/\r/g, "")
+        .replace(/[ \t]+\n/g, "\n")
+        .trim();
+    }
+
+    function pushText(text) {
+      const t = normalizeBodyText(text);
+      if (!t) return;
+      if (segments[segments.length - 1]?.kind === "image" && isDiscourseImageCaption(t)) return;
+      segments.push({ kind: "text", text: t });
+    }
+
+    function pushImages(root) {
+      const images =
+        root.tagName?.toLowerCase() === "img"
+          ? [root]
+          : Array.from(root.querySelectorAll?.("img") || []);
+      for (const img of images) {
+        const src = getImageSrc(img);
+        if (src) segments.push({ kind: "image", src });
+      }
+    }
+
+    function walkMixed(node) {
+      for (const child of Array.from(node.childNodes)) {
+        if (child.nodeType === Node.TEXT_NODE) {
+          const text = (child.nodeValue || "").replace(/\u00a0/g, " ");
+          if (text.trim() && !isDiscourseImageCaption(text.trim())) pushText(text);
+          continue;
+        }
+        if (child.nodeType !== Node.ELEMENT_NODE) continue;
+        if (child.tagName.toLowerCase() === "img" || isImageContainer(child)) {
+          const leftover = leftoverCookedText(child);
+          pushImages(child);
+          if (leftover && !isDiscourseImageCaption(leftover)) pushText(leftover);
+          continue;
+        }
+        if (child.querySelector?.("img,a.lightbox,.lightbox-wrapper,picture,figure")) {
+          walkMixed(child);
+          continue;
+        }
+        const t = leftoverCookedText(child) || cookedNodePlainText(child);
+        if (t && !isDiscourseImageCaption(t)) pushText(t);
+      }
+    }
+
+    function walk(root) {
+      for (const child of Array.from(root.childNodes)) {
+        if (child.nodeType === Node.TEXT_NODE) {
+          const text = (child.nodeValue || "").replace(/\u00a0/g, " ");
+          if (text.trim()) pushText(text);
+          continue;
+        }
+        if (child.nodeType !== Node.ELEMENT_NODE) continue;
+        const tag = child.tagName.toLowerCase();
+        if (tag === "script" || tag === "style") continue;
+        if (tag === "br" || tag === "hr") continue;
+
+        if (isImageContainer(child)) {
+          const leftover = leftoverCookedText(child);
+          if (leftover && !isDiscourseImageCaption(leftover)) {
+            walkMixed(child);
+            continue;
+          }
+          pushImages(child);
+          continue;
+        }
+
+        if (tag === "p" || tag === "div" || /^h[1-6]$/.test(tag)) {
+          const t = cookedNodePlainText(child);
+          if (t) pushText(t);
+          continue;
+        }
+
+        if (tag === "ul" || tag === "ol") {
+          if (child.querySelector?.("img,a.lightbox,.lightbox-wrapper,picture,figure")) {
+            walk(child);
+            continue;
+          }
+          const items = [];
+          let index = 1;
+          for (const item of child.querySelectorAll(":scope > li")) {
+            const bullet = tag === "ol" ? `${index}. ` : "- ";
+            const t = cookedNodePlainText(item);
+            if (t) items.push(bullet + t);
+            index += 1;
+          }
+          if (items.length) pushText(items.join("\n"));
+          continue;
+        }
+
+        if (tag === "blockquote" || tag === "pre" || tag === "li") {
+          if (child.querySelector?.("img,a.lightbox,.lightbox-wrapper,picture,figure")) walk(child);
+          else {
+            const t = cookedNodePlainText(child);
+            if (t) pushText(t);
+          }
+          continue;
+        }
+
+        walk(child);
+      }
+    }
+
+    walk(cooked);
+    return segments;
+  }
+
+  function goBodyFieldLinesFromCooked(cooked, indent = "\t", fallback = "") {
+    if (!cooked) return goBodyFieldLines(fallback, indent);
+    const segments = collectCookedBodySegments(cooked);
+    if (!segments.some((seg) => seg.kind === "image")) {
+      return goBodyFieldLines(cookedToGoBody(cooked) || fallback, indent);
+    }
+
+    const parts = segments.slice();
+    if (parts[0].kind === "image") parts.unshift({ kind: "text", text: "" });
+    if (parts[parts.length - 1].kind === "image") parts.push({ kind: "text", text: "" });
+
+    const lines = [];
+    let textIndex = 0;
+    const textCount = parts.filter((seg) => seg.kind === "text").length;
+    for (const seg of parts) {
+      if (seg.kind === "image") {
+        lines.push(`${indent}${buildImageCodeLine("// ", seg.src)}`);
+        continue;
+      }
+      const prefix = textIndex === 0 ? `${indent}Body: ` : indent;
+      const suffix = textIndex === textCount - 1 ? "," : " +";
+      const rawLines = goRawStringDisplayLines(seg.text);
+      if (rawLines.length === 1) {
+        lines.push(`${prefix}${rawLines[0]}${suffix}`);
+      } else {
+        lines.push(`${prefix}${rawLines[0]}`);
+        for (let i = 1; i < rawLines.length; i += 1) {
+          lines.push(i === rawLines.length - 1 ? `${rawLines[i]}${suffix}` : rawLines[i]);
+        }
+      }
+      textIndex += 1;
     }
     return lines;
   }
@@ -3356,13 +3541,15 @@
   function buildFooterLines(post) {
     const product = getProduct();
     const postNumber = post.getAttribute("data-post-number") || "?";
+    const cooked = post.querySelector(".cooked");
     const ctx = {
       name: getPostAuthorName(post),
       time: getPostTimeText(post),
       floor: getPostFloorLabel(post),
       replyTo: getReplyToName(post),
       postNumber,
-      body: product.paintBody === "raw-string" ? cookedToGoBody(post.querySelector(".cooked")) : ""
+      body: product.paintBody === "raw-string" ? cookedToGoBody(cooked) : "",
+      cooked
     };
     if (postNumber === "1") return product.footerTopic(ctx);
     return product.footerReply(ctx);
@@ -3419,15 +3606,13 @@
       const product = getProduct();
       const embedBody = product.paintBody === "raw-string";
       const paintReplyAsCode = isReply && !embedBody;
-      const imageLines = embedBody ? collectCookedImageLines(cooked, "// ") : [];
       const allLines = [
         ...buildHeaderLines(post),
         ...(embedBody ? [] : collectCookedLineHtml(cooked, paintReplyAsCode)),
-        ...buildFooterLines(post),
-        ...(imageLines.length ? ["", ...imageLines] : [])
+        ...buildFooterLines(post)
       ];
 
-      const signature = `v9:${getProductId()}\n${allLines.join("\n")}`;
+      const signature = `v10:${getProductId()}\n${allLines.join("\n")}`;
       if (codeLines.dataset.signature !== signature) {
         codeLines.dataset.signature = signature;
         codeLines.innerHTML = allLines
@@ -3958,7 +4143,11 @@
       goStringLiteral,
       goRawStringDisplayLines,
       goBodyFieldLines,
+      goBodyFieldLinesFromCooked,
       cookedToGoBody,
+      leftoverCookedText,
+      isDiscourseImageCaption,
+      collectCookedBodySegments,
       collectCookedImageLines,
       buildImageCodeLine,
       sectionTreeLabel,


### PR DESCRIPTION
默认外观改成 GoLand，帖子按 Go 来画，方便顺着读。

- 一楼：`Package` godoc + `type`，正文是注释，图跟在对应段落后
- 回帖：函数 godoc + `func reply_作者_楼层()`
- 引用：`quote.From(作者, 原文)`，不把头像当成图
- 点顶栏可在 GoLand / IDEA / PyCharm 之间循环
- 只换皮，不碰 linux.do 数据